### PR TITLE
Rename wxEVT_GRID_CELL_CHANGE to wxEVT_GRID_CELL_CHANGED

### DIFF
--- a/output/plugins/additional/xml/data.cppcode
+++ b/output/plugins/additional/xml/data.cppcode
@@ -178,7 +178,7 @@ Written by
 		$name = #parent $name->Append${type}Column( $label );
 	</template>
   </templates>
-  
+
   <templates class="dataViewColumn">
 	<template name="declaration">wxDataViewColumn* $name;</template>
 	<template name="construction">
@@ -323,7 +323,7 @@ Written by
 	<template name="evt_entry_OnGridLabelRightDClick">EVT_GRID_LABEL_RIGHT_DCLICK( #handler )</template>
 	<template name="evt_connect_OnGridLabelRightDClick">$name->Connect( wxEVT_GRID_LABEL_RIGHT_DCLICK, #handler, NULL, this );</template>
 	<template name="evt_entry_OnGridCellChange">EVT_GRID_CELL_CHANGE( #handler )</template>
-	<template name="evt_connect_OnGridCellChange">$name->Connect( wxEVT_GRID_CELL_CHANGE, #handler, NULL, this );</template>
+	<template name="evt_connect_OnGridCellChange">$name->Connect( wxEVT_GRID_CELL_CHANGED, #handler, NULL, this );</template>
 	<template name="evt_entry_OnGridSelectCell">EVT_GRID_SELECT_CELL( #handler )</template>
 	<template name="evt_connect_OnGridSelectCell">$name->Connect( wxEVT_GRID_SELECT_CELL, #handler, NULL, this );</template>
 	<template name="evt_entry_OnGridEditorHidden">EVT_GRID_EDITOR_HIDDEN( #handler )</template>
@@ -347,7 +347,7 @@ Written by
 	<template name="evt_entry_OnGridCmdLabelRightDClick">EVT_GRID_CMD_LABEL_RIGHT_DCLICK( $id, #handler )</template>
 	<template name="evt_connect_OnGridCmdLabelRightDClick">$name->Connect( wxEVT_GRID_LABEL_RIGHT_DCLICK, #handler, NULL, this );</template>
 	<template name="evt_entry_OnGridCmdCellChange">EVT_GRID_CMD_CELL_CHANGE( $id, #handler )</template>
-	<template name="evt_connect_OnGridCmdCellChange">$name->Connect( wxEVT_GRID_CELL_CHANGE, #handler, NULL, this );</template>
+	<template name="evt_connect_OnGridCmdCellChange">$name->Connect( wxEVT_GRID_CELL_CHANGED, #handler, NULL, this );</template>
 	<template name="evt_entry_OnGridCmdSelectCell">EVT_GRID_CMD_SELECT_CELL( $id, #handler )</template>
 	<template name="evt_connect_OnGridCmdSelectCell">$name->Connect( wxEVT_GRID_SELECT_CELL, #handler, NULL, this );</template>
 	<template name="evt_entry_OnGridCmdEditorHidden">EVT_GRID_CMD_EDITOR_HIDDEN( $id, #handler )</template>
@@ -371,7 +371,7 @@ Written by
 	<template name="evt_entry_OnGridCmdEditorCreated">EVT_GRID_CMD_EDITOR_CREATED( $id, #handler )</template>
 	<template name="evt_connect_OnGridCmdEditorCreated">$name->Connect( wxEVT_GRID_EDITOR_CREATED, #handler, NULL, this );</template>
   </templates>
-  
+
 	<templates class="wxPropertyGrid">
 		<template name="declaration">#class* $name;</template>
 		<template name="construction">$name = new #class(#wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @});</template>
@@ -408,7 +408,7 @@ Written by
 		<template name="evt_entry_OnPropertyGridChanged">EVT_PG_CHANGED( $id, #handler )</template>
 		<template name="evt_connect_OnPropertyGridChanged">$name->Connect( wxEVT_PG_CHANGED, #handler, NULL, this );</template>
 	</templates>
-	
+
 	<templates class="propGridItem">
 		<template name="declaration">wxPGProperty* $name;</template>
 		<template name="construction">
@@ -422,7 +422,7 @@ Written by
 			@}
 		</template>
 	</templates>
-	
+
 	<templates class="propGridPage">
 		<template name="declaration">wxPropertyGridPage* $name;</template>
 		<template name="construction">

--- a/output/plugins/additional/xml/data.luacode
+++ b/output/plugins/additional/xml/data.luacode
@@ -33,7 +33,7 @@ Lua code generation written by
 	<template name="evt_connect_OnTreeItemGetTooltip">#utbl$name:Connect( wx.wxEVT_COMMAND_TREE_ITEM_GETTOOLTIP, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnTreeStateImageClick">#utbl$name:Connect( wx.wxEVT_COMMAND_TREE_STATE_IMAGE_CLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
   </templates>
-  
+
 	<templates class="wxDataViewCtrl">
 		<template name="declaration">#class* $name;</template>
 		<template name="construction">
@@ -108,13 +108,13 @@ Lua code generation written by
 		<template name="evt_connect_OnDataViewListCtrlItemDropPossible">-- event #utbl$name:OnDataViewListCtrlItemDropPossible isn't currently supported by wxLua</template>
 		<template name="evt_connect_OnDataViewListCtrlItemDrop">-- event #utbl$name:OnDataViewListCtrlItemDrop isn't currently supported by wxLua</template>
 	</templates>
-	
+
 	<templates class="dataViewListColumn">
 		<template name="construction">
 			@# WARNING: wxLua code generation isn't supported for this widget yet. #nl
 		</template>
 	</templates>
-	
+
 	<templates class="dataViewColumn">
 		<template name="construction">
 			@# WARNING: wxLua code generation isn't supported for this widget yet. #nl
@@ -224,7 +224,7 @@ Lua code generation written by
 	<template name="evt_connect_OnGridLabelRightClick">#utbl$name:Connect( wx.wxEVT_GRID_LABEL_RIGHT_CLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridLabelLeftDClick">#utbl$name:Connect( wx.wxEVT_GRID_LABEL_LEFT_DCLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridLabelRightDClick">#utbl$name:Connect( wx.wxEVT_GRID_LABEL_RIGHT_DCLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
-	<template name="evt_connect_OnGridCellChange">#utbl$name:Connect( wx.wxEVT_GRID_CELL_CHANGE, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+	<template name="evt_connect_OnGridCellChange">#utbl$name:Connect( wx.wxEVT_GRID_CELL_CHANGED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridSelectCell">#utbl$name:Connect( wx.wxEVT_GRID_SELECT_CELL, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridEditorHidden">#utbl$name:Connect( wx.wxEVT_GRID_EDITOR_HIDDEN, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridEditorShown">#utbl$name:Connect( wx.wxEVT_GRID_EDITOR_SHOWN, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
@@ -236,7 +236,7 @@ Lua code generation written by
 	<template name="evt_connect_OnGridCmdLabelRightClick">#utbl$name:Connect( wx.wxEVT_GRID_LABEL_RIGHT_CLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridCmdLabelLeftDClick">#utbl$name:Connect( wx.wxEVT_GRID_LABEL_LEFT_DCLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridCmdLabelRightDClick">#utbl$name:Connect( wx.wxEVT_GRID_LABEL_RIGHT_DCLICK, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
-	<template name="evt_connect_OnGridCmdCellChange">#utbl$name:Connect( wx.wxEVT_GRID_CELL_CHANGE, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+	<template name="evt_connect_OnGridCmdCellChange">#utbl$name:Connect( wx.wxEVT_GRID_CELL_CHANGED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridCmdSelectCell">#utbl$name:Connect( wx.wxEVT_GRID_SELECT_CELL, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridCmdEditorHidden">#utbl$name:Connect( wx.wxEVT_GRID_EDITOR_HIDDEN, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridCmdEditorShown">#utbl$name:Connect( wx.wxEVT_GRID_EDITOR_SHOWN, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
@@ -249,7 +249,7 @@ Lua code generation written by
 	<template name="evt_connect_OnGridEditorCreated">#utbl$name:Connect( wx.wxEVT_GRID_EDITOR_CREATED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	<template name="evt_connect_OnGridCmdEditorCreated">#utbl$name:Connect( wx.wxEVT_GRID_EDITOR_CREATED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
   </templates>
-  
+
   	<templates class="wxPropertyGrid">
 		<template name="construction">
 			@# WARNING: wxLua code generation isn't supported for this widget yet. #nl
@@ -263,13 +263,13 @@ Lua code generation written by
 			#utbl$name = wx.wxWindow( #utbl#wxparent $name )
 		</template>
 	</templates>
-	
+
 	<templates class="propGridItem">
 		<template name="construction">
 			@# WARNING: wxLua code generation isn't supported for this widget yet. #nl
 		</template>
 	</templates>
-	
+
 	<templates class="propGridPage">
 		<template name="construction">
 			@# WARNING: wxLua code generation isn't supported for this widget yet. #nl

--- a/output/plugins/additional/xml/data.phpcode
+++ b/output/plugins/additional/xml/data.phpcode
@@ -117,7 +117,7 @@ PHP code generation written by
 		@/* WARNING: PHP code generation isn't supported for this widget yet. */#nl
 	</template>
   </templates>
-  
+
   <templates class="dataViewColumn">
 	<template name="construction">
 		@/* WARNING: PHP code generation isn't supported for this widget yet. */#nl
@@ -228,7 +228,7 @@ PHP code generation written by
 	<template name="evt_connect_OnGridLabelRightClick">@$this->$name->Connect( wxEVT_GRID_LABEL_RIGHT_CLICK, #handler );</template>
 	<template name="evt_connect_OnGridLabelLeftDClick">@$this->$name->Connect( wxEVT_GRID_LABEL_LEFT_DCLICK, #handler );</template>
 	<template name="evt_connect_OnGridLabelRightDClick">@$this->$name->Connect( wxEVT_GRID_LABEL_RIGHT_DCLICK, #handler );</template>
-	<template name="evt_connect_OnGridCellChange">@$this->$name->Connect( wxEVT_GRID_CELL_CHANGE, #handler );</template>
+	<template name="evt_connect_OnGridCellChange">@$this->$name->Connect( wxEVT_GRID_CELL_CHANGED, #handler );</template>
 	<template name="evt_connect_OnGridSelectCell">@$this->$name->Connect( wxEVT_GRID_SELECT_CELL, #handler );</template>
 	<template name="evt_connect_OnGridEditorHidden">@$this->$name->Connect( wxEVT_GRID_EDITOR_HIDDEN, #handler );</template>
 	<template name="evt_connect_OnGridEditorShown">@$this->$name->Connect( wxEVT_GRID_EDITOR_SHOWN, #handler );</template>
@@ -240,7 +240,7 @@ PHP code generation written by
 	<template name="evt_connect_OnGridCmdLabelRightClick">@$this->$name->Connect( wxEVT_GRID_LABEL_RIGHT_CLICK, #handler );</template>
 	<template name="evt_connect_OnGridCmdLabelLeftDClick">@$this->$name->Connect( wxEVT_GRID_LABEL_LEFT_DCLICK, #handler );</template>
 	<template name="evt_connect_OnGridCmdLabelRightDClick">@$this->$name->Connect( wxEVT_GRID_LABEL_RIGHT_DCLICK, #handler );</template>
-	<template name="evt_connect_OnGridCmdCellChange">@$this->$name->Connect( wxEVT_GRID_CELL_CHANGE, #handler );</template>
+	<template name="evt_connect_OnGridCmdCellChange">@$this->$name->Connect( wxEVT_GRID_CELL_CHANGED, #handler );</template>
 	<template name="evt_connect_OnGridCmdSelectCell">@$this->$name->Connect( wxEVT_GRID_SELECT_CELL, #handler );</template>
 	<template name="evt_connect_OnGridCmdEditorHidden">@$this->$name->Connect( wxEVT_GRID_EDITOR_HIDDEN, #handler );</template>
 	<template name="evt_connect_OnGridCmdEditorShown">@$this->$name->Connect( wxEVT_GRID_EDITOR_SHOWN, #handler );</template>
@@ -267,17 +267,17 @@ PHP code generation written by
 			@$this->$name = new wxWindow( #wxparent $name );
 		</template>
 	</templates>
-	
+
 	<templates class="propGridItem">
 		<template name="construction">
 			@/* WARNING: PHP code generation isn't supported for this widget yet. */#nl
 		</template>
 	</templates>
-	
+
 	<templates class="propGridPage">
 		<template name="construction">
 			@/* WARNING: PHP code generation isn't supported for this widget yet. */#nl
 		</template>
 	</templates>
-	
+
 </codegen>

--- a/output/plugins/additional/xml/data.xml
+++ b/output/plugins/additional/xml/data.xml
@@ -132,7 +132,7 @@ Written by
 	<event name="OnGridLabelRightClick" class="wxGridEvent" help="The user clicked a label with the right mouse button. Processes a wxEVT_GRID_LABEL_RIGHT_CLICK." />
 	<event name="OnGridLabelLeftDClick" class="wxGridEvent" help="The user double-clicked a label with the left mouse button. Processes a wxEVT_GRID_LABEL_LEFT_DCLICK." />
 	<event name="OnGridLabelRightDClick" class="wxGridEvent" help="The user double-clicked a label with the right mouse button. Processes a wxEVT_GRID_LABEL_RIGHT_DCLICK." />
-	<event name="OnGridCellChange" class="wxGridEvent" help="The user changed the data in a cell. Processes a wxEVT_GRID_CELL_CHANGE." />
+	<event name="OnGridCellChange" class="wxGridEvent" help="The user changed the data in a cell. Processes a wxEVT_GRID_CELL_CHANGED." />
 	<event name="OnGridSelectCell" class="wxGridEvent" help="The user moved to, and selected a cell. Processes a wxEVT_GRID_SELECT_CELL." />
 	<event name="OnGridEditorHidden" class="wxGridEvent" help="The editor for a cell was hidden. Processes a wxEVT_GRID_EDITOR_HIDDEN." />
 	<event name="OnGridEditorShown" class="wxGridEvent" help="The editor for a cell was shown. Processes a wxEVT_GRID_EDITOR_SHOWN." />
@@ -144,7 +144,7 @@ Written by
 	<event name="OnGridCmdLabelRightClick" class="wxGridEvent" help="The user clicked a label with the right mouse button; variant taking a window identifier. Processes a wxEVT_GRID_LABEL_RIGHT_CLICK." />
 	<event name="OnGridCmdLabelLeftDClick" class="wxGridEvent" help="The user double-clicked a label with the left mouse button; variant taking a window identifier. Processes a wxEVT_GRID_LABEL_LEFT_DCLICK." />
 	<event name="OnGridCmdLabelRightDClick" class="wxGridEvent" help="The user double-clicked a label with the right mouse button; variant taking a window identifier. Processes a wxEVT_GRID_LABEL_RIGHT_DCLICK." />
-	<event name="OnGridCmdCellChange" class="wxGridEvent" help="The user changed the data in a cell; variant taking a window identifier. Processes a wxEVT_GRID_CELL_CHANGE." />
+	<event name="OnGridCmdCellChange" class="wxGridEvent" help="The user changed the data in a cell; variant taking a window identifier. Processes a wxEVT_GRID_CELL_CHANGED." />
 	<event name="OnGridCmdSelectCell" class="wxGridEvent" help="The user moved to, and selected a cell; variant taking a window identifier. Processes a wxEVT_GRID_SELECT_CELL." />
 	<event name="OnGridCmdEditorHidden" class="wxGridEvent" help="The editor for a cell was hidden; variant taking a window identifier. Processes a wxEVT_GRID_EDITOR_HIDDEN." />
 	<event name="OnGridCmdEditorShown" class="wxGridEvent" help="The editor for a cell was shown; variant taking a window identifier. Processes a wxEVT_GRID_EDITOR_SHOWN." />


### PR DESCRIPTION
Since wxWidgets 3.1 this event has been renamed to `wxEVT_GRID_CELL_CHANGED`. The new name also works with wxWidgets 3.0.