### PR TITLE
Build with AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+version: 1.0.{build}
+environment:
+  MSYSTEM: MINGW32
+install:
+- cmd: >-
+    cinst -y InnoSetup
+
+    C:\msys64\usr\bin\bash -lc "pacman -S --needed --noconfirm mingw-w64-i686-wxWidgets"
+build_script:
+- cmd: >-
+    git submodule update --init
+
+
+    create_build_files4.bat --wx-root=/mingw32/bin --force-wx-config --disable-mediactrl
+
+
+    C:\msys64\usr\bin\bash -lc "ln -s /mingw32/include/binutils/bfd.h /mingw32/include/bfd.h"
+
+    C:\msys64\usr\bin\bash -lc "ln -s /mingw32/include/binutils/symcat.h /mingw32/include/symcat.h"
+
+    C:\msys64\usr\bin\bash -lc "ln -s /mingw32/lib/binutils/libbfd.a /mingw32/lib/libbfd.a"
+
+    C:\msys64\usr\bin\bash -lc "ln -s /mingw32/lib/binutils/libiberty.a /mingw32/lib/libiberty.a"
+
+
+    C:\msys64\usr\bin\bash -lc "cd '%cd%'/build/3.0/gmake && sed 's!\$(LDFLAGS) \$(RESOURCES) \$(ARCH) \$(LIBS)!\$(LIBS) \$(LDFLAGS) \$(RESOURCES) \$(ARCH)!g' *.make -i"
+
+    C:\msys64\usr\bin\bash -lc "cd '%cd%'/build/3.0/gmake && sed 's!-lbfd!-lbfd -lz!g' *.make -i"
+
+
+    C:\msys64\usr\bin\bash -lc "cd '%cd%'/build/3.0/gmake && make config=release"

--- a/build/premake/wxwidgets.lua
+++ b/build/premake/wxwidgets.lua
@@ -133,13 +133,13 @@ function wx_config(options)
     if _OPTIONS["disable-shared"] then
         useStatic = "yes"
     end
-	
+
 -- Use wx-config
 	local useWXConfig = "no"
     if _OPTIONS["force-wx-config"] then
         useWXConfig = "yes"
     end
-	
+
     wx_config_Private( options.Root             or "",
 							options.Debug				or "",
 							options.Host				or "",
@@ -234,7 +234,7 @@ function wx_config_Private(wxRoot, wxDebug, wxHost, wxVersion, wxStatic, wxUnico
 				end
 				links { "wxregex" .. wxBuildType }
 			end
-			
+
 			if string.match(_ACTION, "vs(.*)$") then
 				-- link with MSVC support libraries
 				for i, lib in ipairs({"comctl32", "rpcrt4", "winmm", "advapi32", "wsock32", "Dbghelp"}) do
@@ -265,24 +265,24 @@ function wx_config_Private(wxRoot, wxDebug, wxHost, wxVersion, wxStatic, wxUnico
 		if _ACTION == "codelite" then
 			-- set the parameters to the current configuration
 			buildoptions {"$(shell " .. configCmd .." --cxxflags)"}
-			
+
 			if wxWithoutLibs == "no" then
 				linkoptions  {"$(shell " .. configCmd .." --libs " .. wxLibs .. ")"}
 			end
-			
+
 			if os.get() == "windows" then
 				resoptions  {"$(shell " .. configCmd .." --rcflags)"}
 			end
 		else
 			-- set the parameters to the current configuration
 			buildoptions {"`" .. configCmd .." --cxxflags`"}
-			
+
 			if wxWithoutLibs == "no" then
 				linkoptions  {"`" .. configCmd .." --libs " .. wxLibs .. "`"}
 			end
-			
+
 			if os.get() == "windows" then
-				resoptions  {"`" .. configCmd .." --rcflags`"}
+				resoptions  {"`" .. configCmd .." --rcflags || " .. configCmd .." --rescomp | cut -d' ' -f2-`"}
 			end
 		end
     end


### PR DESCRIPTION
This uses [MSYS2](https://msys2.github.io/) to compile, which includes wxWidgets. It even has premake, but for now it's still use the .bat file and therefore the premake4.exe included in git.

The wx-config binary included in wxWidgets is using --rescomp instead of --rcflags. `wx-config --rescomp` returns the full compiler command, e. g.

```sh
$ wx-config --rescomp
windres --include-dir C:/msys64/mingw32/include/wx-3.0 --define __WIN32__ --define __GNUWIN32__
```

That's why I added the `| cut -d' ' -f2-`, to remove the "windres".

These lines

```sh
ln -s /mingw32/include/binutils/bfd.h /mingw32/include/bfd.h
ln -s /mingw32/include/binutils/symcat.h /mingw32/include/symcat.h
ln -s /mingw32/lib/binutils/libbfd.a /mingw32/lib/libbfd.a
ln -s /mingw32/lib/binutils/libiberty.a /mingw32/lib/libiberty.a
```

are needed because MSYS2 adds those headers and libs in a subfolder, I don't know why (I've asked on the msys2 mailing list [here](https://sourceforge.net/p/msys2/mailman/message/35406062/)).

```
sed 's!\$(LDFLAGS) \$(RESOURCES) \$(ARCH) \$(LIBS)!\$(LIBS) \$(LDFLAGS) \$(RESOURCES) \$(ARCH)!g' *.make -i"
```
Somehow MinGW doesn't like that wxWidgets' libs come before static libs. That's why I swap LDFLAGS and LIBS here.

```
sed 's!-lbfd!-lbfd -lz!g' *.make -i"
```
bfd.a needs zlib. Maybe it can be added in the lua scripts in the future, but I didn't want to mess with them for now.

Besides these few hacks it works fine, you can see the result here: https://ci.appveyor.com/project/jhasse/wxformbuilder