### PR TITLE
Upload Win32 build as appveyor artifact to allow downloading binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # wxFormBuilder [![Build status](https://ci.appveyor.com/api/projects/status/yxpn19g0st7l9r8x?svg=true)](https://ci.appveyor.com/project/jhasse/wxformbuilder-461d5)
 
+## Download Binaries
+
+### Windows
+* wxWidgets 3.0 32-bit [Download](https://ci.appveyor.com/api/projects/jhasse/wxformbuilder-461d5/artifacts/wxFormBuilder_win32.zip?branch=master) (last successful build)
+
 ## Install From Source
 
 ### Windows (MSYS2)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,3 +29,7 @@ build_script:
 
 
     C:\msys64\usr\bin\bash -lc "cd '%cd%'/build/3.0/gmake && make config=release"
+
+    7z a -r wxFormBuilder_win32.zip %cd%\output\*.* C:\msys64\mingw32\bin\wx*.dll C:\msys64\mingw32\bin\libstdc++*.dll C:\msys64\mingw32\bin\libgcc*.dll C:\msys64\mingw32\bin\libintl*.dll C:\msys64\mingw32\bin\libexpat*.dll C:\msys64\mingw32\bin\libjpeg*.dll C:\msys64\mingw32\bin\libpng*.dll C:\msys64\mingw32\bin\libtiff*.dll C:\msys64\mingw32\bin\zlib*.dll C:\msys64\mingw32\bin\libwinpthread*.dll C:\msys64\mingw32\bin\libiconv*.dll C:\msys64\mingw32\bin\liblzma*.dll
+
+    appveyor PushArtifact wxFormBuilder_win32.zip


### PR DESCRIPTION
Package a successful appveyor build as an artifact and add a download link to the README file to allow easy access to current Windows binaries.

This could be expanded to include setups, if they would be built in the appveyor script.