### PR TITLE
Fix for 2 wxPyDeprecationWarning with the latest wxPython==4.0.0a1

### DIFF
--- a/output/plugins/common/xml/menutoolbar.pythoncode
+++ b/output/plugins/common/xml/menutoolbar.pythoncode
@@ -101,7 +101,7 @@ Python code generation writen by
 		@{
 			self.$name.SetBitmap( $bitmap ) #nl
 		@}
-		self.#parent $name.AppendItem( self.$name ) #nl
+		self.#parent $name.Append( self.$name ) #nl
 		#ifequal $enabled "0"
 			@{ self.$name.Enable( $enabled ) #nl @}
 		#ifequal $kind "wxITEM_CHECK"
@@ -196,7 +196,7 @@ Python code generation writen by
 			#ifequal $center_pane "1" @{.CentrePane()@}
 			#ifequal $default_pane "1" @{.DefaultPane()@}
 			#ifequal $toolbar_pane "1" @{.ToolbarPane()@}
-			)				
+			)
 		@}
 		@}
 	</template>
@@ -229,7 +229,7 @@ Python code generation writen by
 		#ifequal #parent $aui_managed "1"
 		@{ #nl
 			self.m_mgr.AddPane( self.$name, wx.aui.AuiPaneInfo()#ifnotnull $aui_name
-			@{.Name( $aui_name )@}.$docking()#ifnotnull $caption 
+			@{.Name( $aui_name )@}.$docking()#ifnotnull $caption
 			@{.Caption( $caption )@}#ifequal $caption_visible "0"
 			@{.CaptionVisible( $caption_visible )@}#ifequal $close_button "0"
 			@{.CloseButton( $close_button )@}#ifequal $maximize_button "1"
@@ -241,10 +241,10 @@ Python code generation writen by
 			@{.Hide()@}#ifequal $moveable "0"
 			@{.Movable( $moveable )@}#ifnotnull $dock
 			@{.$dock()#ifequal $dock "Float"
-				@{.FloatingPosition( $pane_position )@}	
+				@{.FloatingPosition( $pane_position )@}
 			@}#ifnotnull $resize
 			@{.$resize()#ifequal $resize "Resizable"
-				@{.FloatingSize( $pane_size )@}	
+				@{.FloatingSize( $pane_size )@}
 			@}#ifequal $dock_fixed "1"
 			@{.DockFixed( $dock_fixed )@}#ifequal $BottomDockable "0"
 			@{.BottomDockable( $BottomDockable )@}#ifequal $TopDockable "0"
@@ -258,7 +258,7 @@ Python code generation writen by
 			@{.CentrePane()@}#ifequal $default_pane "1"
 			@{.DefaultPane()@}#ifequal $toolbar_pane "1"
 			@{.ToolbarPane()@}
-			)		
+			)
 		@}
 		@}
 		</template>
@@ -310,7 +310,7 @@ Python code generation writen by
   <templates class="toolSeparator">
     <template name="construction">self.#parent $name.AddSeparator()</template>
   </templates>
-  
+
   <templates class="wxInfoBar">
     <template name="construction">self.$name = #class( #wxparent $name )</template>
 	<template name="settings">
@@ -318,5 +318,5 @@ Python code generation writen by
 		self.$name.SetEffectDuration( $duration )
 	</template>
   </templates>
-  
+
 </codegen>

--- a/output/plugins/forms/xml/forms.pythoncode
+++ b/output/plugins/forms/xml/forms.pythoncode
@@ -40,7 +40,7 @@ Python code generation writen by
 		<template name="evt_connect_OnIdle">self.Bind( wx.EVT_IDLE, #handler )</template>
 		<template name="evt_disconnect_OnIdle">self.Unbind( wx.EVT_IDLE )</template>
 	</templates>
-  
+
 	<templates class="AUI Events">
 		<template name="evt_connect_OnAuiPaneButton">self.Bind( wx.aui.EVT_AUI_PANE_BUTTON, #handler )</template>
 		<template name="evt_disconnect_OnAuiPaneButton">self.Unbind( wx.aui.EVT_AUI_PANE_BUTTON )</template>
@@ -55,7 +55,7 @@ Python code generation writen by
 		<template name="evt_connect_OnAuiFindManager">self.Bind( wx.aui.EVT_AUI_FIND_MANAGER, #handler )</template>
 		<template name="evt_disconnect_OnAuiFindManager">self.Unbind( wx.aui.EVT_AUI_FIND_MANAGER )</template>
 	</templates>
-	
+
 	<templates class="Frame">
 		<!-- The duplication of these templates is not ideal, but the ripup is too big to be done before version 3 -->
 		<template name="base">
@@ -85,8 +85,8 @@ Python code generation writen by
 			@{import wx.aui @}
 		</template>
 		<template name="settings">
-			self.SetSizeHintsSz( $minimum_size, $maximum_size ) #nl
-			
+			self.SetSizeHints( $minimum_size, $maximum_size ) #nl
+
 			#ifnotnull $window_extra_style
 			@{ self.SetExtraStyle( $window_extra_style ) #nl @}
 
@@ -110,9 +110,9 @@ Python code generation writen by
 
 			#ifnotnull $tooltip
 			@{ self.SetToolTipString( $tooltip ) #nl @}
-			
+
 			#ifequal $aui_managed "1"
-			@{ 
+			@{
 				self.m_mgr = wx.aui.AuiManager() #nl
 				self.m_mgr.SetManagedWindow( self ) #nl
 				#ifnotnull $aui_manager_style
@@ -121,7 +121,7 @@ Python code generation writen by
 		</template>
 		<template name="after_addchild">
 		  #ifequal $aui_managed "1"
-			@{ #nl self.m_mgr.Update() @} 
+			@{ #nl self.m_mgr.Update() @}
 			#ifnotnull $center
 			@{ #nl self.Centre( $center ) @}
 		</template>
@@ -141,9 +141,9 @@ Python code generation writen by
 		<template name="evt_disconnect_OnLeaveWindow">self.Unbind( wx.EVT_LEAVE_WINDOW )</template>
 		<template name="evt_connect_OnLeftDClick">self.Bind( wx.EVT_LEFT_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnLeftDClick">self.Unbind( wx.EVT_LEFT_DCLICK )</template>
-		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>  
+		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>
 		<template name="evt_disconnect_OnLeftDown">self.Unbind( wx.EVT_LEFT_DOWN )</template>
-		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>  
+		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>
 		<template name="evt_disconnect_OnLeftUp">self.Unbind( wx.EVT_LEFT_UP )</template>
 		<template name="evt_connect_OnMiddleDClick">self.Bind( wx.EVT_MIDDLE_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnMiddleDClick">self.Unbind( wx.EVT_MIDDLE_DCLICK )</template>
@@ -239,12 +239,12 @@ Python code generation writen by
 
 			#ifnotnull $minimum_size
 			@{ self.SetMinSize( $minimum_size ) #nl @}
-			
+
 			#ifnotnull $maximum_size
 			@{ self.SetMaxSize( $maximum_size ) #nl @}
 
 			#ifequal $aui_managed "1"
-			@{ 
+			@{
 				self.m_mgr = wx.aui.AuiManager() #nl
 				self.m_mgr.SetManagedWindow( self ) #nl
 				#ifnotnull $aui_manager_style
@@ -253,7 +253,7 @@ Python code generation writen by
 		</template>
 		<template name="after_addchild">
 			#ifequal $aui_managed "1"
-			@{ #nl self.m_mgr.Update() @} 
+			@{ #nl self.m_mgr.Update() @}
 		</template>
 		<template name="evt_connect_OnInitDialog">self.Bind( wx.EVT_INIT_DIALOG, #handler )</template>
 		<template name="evt_disconnect_OnInitDialog">self.Unbind( wx.EVT_INIT_DIALOG )</template>
@@ -273,9 +273,9 @@ Python code generation writen by
 		<template name="evt_disconnect_OnLeaveWindow">self.Unbind( wx.EVT_LEAVE_WINDOW )</template>
 		<template name="evt_connect_OnLeftDClick">self.Bind( wx.EVT_LEFT_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnLeftDClick">self.Unbind( wx.EVT_LEFT_DCLICK )</template>
-		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>  
+		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>
 		<template name="evt_disconnect_OnLeftDown">self.Unbind( wx.EVT_LEFT_DOWN )</template>
-		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>  
+		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>
 		<template name="evt_disconnect_OnLeftUp">self.Unbind( wx.EVT_LEFT_UP )</template>
 		<template name="evt_connect_OnMiddleDClick">self.Bind( wx.EVT_MIDDLE_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnMiddleDClick">self.Unbind( wx.EVT_MIDDLE_DCLICK )</template>
@@ -349,8 +349,8 @@ Python code generation writen by
 			#ifequal $aui_managed "1"
 			@{import wx.aui @}</template>
 		<template name="settings">
-			self.SetSizeHintsSz( $minimum_size, $maximum_size ) #nl
-			
+			self.SetSizeHints( $minimum_size, $maximum_size ) #nl
+
 			#ifnotnull $window_extra_style
 			@{ self.SetExtraStyle( self.GetExtraStyle() | $window_extra_style ) #nl @}
 
@@ -376,7 +376,7 @@ Python code generation writen by
 			@{ self.SetToolTipString( $tooltip ) #nl @}
 
 			#ifequal $aui_managed "1"
-			@{ 
+			@{
 				self.m_mgr = wx.aui.AuiManager() #nl
 				self.m_mgr.SetManagedWindow( self ) #nl
 				#ifnotnull $aui_manager_style
@@ -385,7 +385,7 @@ Python code generation writen by
 		</template>
 		<template name="after_addchild">
 			#ifequal $aui_managed "1"
-			@{ #nl self.m_mgr.Update() @} 
+			@{ #nl self.m_mgr.Update() @}
 			#ifnotnull $center
 			@{ #nl self.Centre( $center ) @}
 		</template>
@@ -407,9 +407,9 @@ Python code generation writen by
 		<template name="evt_disconnect_OnLeaveWindow">self.Unbind( wx.EVT_LEAVE_WINDOW )</template>
 		<template name="evt_connect_OnLeftDClick">self.Bind( wx.EVT_LEFT_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnLeftDClick">self.Unbind( wx.EVT_LEFT_DCLICK )</template>
-		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>  
+		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>
 		<template name="evt_disconnect_OnLeftDown">self.Unbind( wx.EVT_LEFT_DOWN )</template>
-		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>  
+		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>
 		<template name="evt_disconnect_OnLeftUp">self.Unbind( wx.EVT_LEFT_UP )</template>
 		<template name="evt_connect_OnMiddleDClick">self.Bind( wx.EVT_MIDDLE_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnMiddleDClick">self.Unbind( wx.EVT_MIDDLE_DCLICK )</template>
@@ -484,7 +484,7 @@ Python code generation writen by
 			#ifnotnull $extra_style
 			@{ self.SetExtraStyle( wx.wizard.WIZARD_EX_HELPBUTTON ) #nl @}
 
-			self.SetSizeHintsSz( $minimum_size, $maximum_size ) #nl
+			self.SetSizeHints( $minimum_size, $maximum_size ) #nl
 
 			#ifnotnull $font
 			@{ self.SetFont( $font ) #nl @}
@@ -528,9 +528,9 @@ Python code generation writen by
 		<template name="evt_disconnect_OnLeaveWindow">self.Unbind( wx.EVT_LEAVE_WINDOW )</template>
 		<template name="evt_connect_OnLeftDClick">self.Bind( wx.EVT_LEFT_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnLeftDClick">self.Unbind( wx.EVT_LEFT_DCLICK )</template>
-		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>  
+		<template name="evt_connect_OnLeftDown">self.Bind( wx.EVT_LEFT_DOWN, #handler )</template>
 		<template name="evt_disconnect_OnLeftDown">self.Unbind( wx.EVT_LEFT_DOWN )</template>
-		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>  
+		<template name="evt_connect_OnLeftUp">self.Bind( wx.EVT_LEFT_UP, #handler )</template>
 		<template name="evt_disconnect_OnLeftUp">self.Unbind( wx.EVT_LEFT_UP )</template>
 		<template name="evt_connect_OnMiddleDClick">self.Bind( wx.EVT_MIDDLE_DCLICK, #handler )</template>
 		<template name="evt_disconnect_OnMiddleDClick">self.Unbind( wx.EVT_MIDDLE_DCLICK )</template>
@@ -644,7 +644,7 @@ Python code generation writen by
 				@{ self.SetToolSeparation( $separation ) #nl @}
 			@}
 
-			#ifnotnull $margins 
+			#ifnotnull $margins
 			@{ self.SetMargins( $margins ) #nl @}
 
 			#ifnotnull $packing


### PR DESCRIPTION
A fix for the following deprecation warning  in the generated python code, may be related to 
this [issue](https://github.com/wxFormBuilder/wxFormBuilder/issues/275)

``` 
wxPyDeprecationWarning: Call to deprecated item. Use Append instead.
  self.m_menu1.AppendItem( self.m_menuItem1 )
```

And 

```
wxPyDeprecationWarning: Call to deprecated item. Use SetSizeHints instead.
  self.SetSizeHintsSz( wx.DefaultSize, wx.DefaultSize )
```