### PR TITLE
Updated 'AddSpacer' to new syntax in Phoenix

### DIFF
--- a/output/plugins/layout/xml/layout.pythoncode
+++ b/output/plugins/layout/xml/layout.pythoncode
@@ -38,13 +38,13 @@ Python code generation writen by
   <templates class="sizeritem">
     <template name="window_add">#parent $name.Add( self.#child $name, $proportion, $flag, $border ) #nl</template>
     <template name="sizer_add">#parent $name.Add( #child $name, $proportion, $flag, $border ) #nl</template>
-    <template name="spacer_add">#parent $name.AddSpacer( ( #child $width, #child $height), $proportion, $flag, $border ) #nl</template>
+    <template name="spacer_add">#parent $name.Add( ( #child $width, #child $height), $proportion, $flag, $border ) #nl</template>
   </templates>
 
   <templates class="gbsizeritem">
     <template name="window_add">#parent $name.Add( self.#child $name, wx.GBPosition( $row, $column ), wx.GBSpan( $rowspan, $colspan ), $flag, $border ) #nl</template>
     <template name="sizer_add">#parent $name.Add( #child $name, wx.GBPosition( $row, $column ), wx.GBSpan( $rowspan, $colspan ), $flag, $border ) #nl</template>
-    <template name="spacer_add">#parent $name.AddSpacer( ( #child $width, #child $height ), wx.GBPosition( $row, $column ), wx.GBSpan( $rowspan, $colspan ), $flag, $border ) #nl</template>
+    <template name="spacer_add">#parent $name.Add( ( #child $width, #child $height ), wx.GBPosition( $row, $column ), wx.GBSpan( $rowspan, $colspan ), $flag, $border ) #nl</template>
   </templates>
 
   <templates class="wxBoxSizer">


### PR DESCRIPTION
Changed 'AddSpacer' to 'Add' as now 'AddSpacer' has only one argument. If it does what I intend for it to do, it should fix #303 and #275. 