### PR TITLE
Syntax fixes for SetToolTipString and wxST_SIZEGRIP

### DIFF
--- a/output/plugins/common/xml/menutoolbar.xml
+++ b/output/plugins/common/xml/menutoolbar.xml
@@ -27,7 +27,7 @@ Written by
     <property name="name" type="text">m_statusBar</property>
     <property name="fields" type="uint"  help="Number of fields in the statusbar.">1</property>
     <property name="style" type="bitlist">
-      <option name="wxST_SIZEGRIP"       help="On Windows, displays a gripper at right-hand side of the status bar." />wxST_SIZEGRIP</property>
+      <option name="wxSTB_SIZEGRIP"       help="On Windows, displays a gripper at right-hand side of the status bar." />wxSTB_SIZEGRIP</property>
   </objectinfo>
 
   <objectinfo class="wxMenuBar" icon="menubar.xpm" type="menubar" startgroup="1">

--- a/output/plugins/forms/xml/forms.pythoncode
+++ b/output/plugins/forms/xml/forms.pythoncode
@@ -109,7 +109,7 @@ Python code generation writen by
 			@{ self.Hide() #nl @}
 
 			#ifnotnull $tooltip
-			@{ self.SetToolTipString( $tooltip ) #nl @}
+			@{ self.SetToolTip( $tooltip ) #nl @}
 
 			#ifequal $aui_managed "1"
 			@{
@@ -235,7 +235,7 @@ Python code generation writen by
 			@{ self.Hide() #nl @}
 
 			#ifnotnull $tooltip
-			@{ self.SetToolTipString( $tooltip ) #nl @}
+			@{ self.SetToolTip( $tooltip ) #nl @}
 
 			#ifnotnull $minimum_size
 			@{ self.SetMinSize( $minimum_size ) #nl @}
@@ -373,7 +373,7 @@ Python code generation writen by
 			@{ self.Hide() #nl @}
 
 			#ifnotnull $tooltip
-			@{ self.SetToolTipString( $tooltip ) #nl @}
+			@{ self.SetToolTip( $tooltip ) #nl @}
 
 			#ifequal $aui_managed "1"
 			@{
@@ -502,7 +502,7 @@ Python code generation writen by
 			@{ self.Hide() #nl @}
 
 			#ifnotnull $tooltip
-			@{ self.SetToolTipString( $tooltip ) #nl @}
+			@{ self.SetToolTip( $tooltip ) #nl @}
 
             self.m_pages = [] #nl
 		</template>

--- a/output/xml/default.pythoncode
+++ b/output/xml/default.pythoncode
@@ -32,7 +32,7 @@
 			@{ self.$name.Hide() #nl @}
 
 			#ifnotnull $tooltip
-			@{ self.$name.SetToolTipString( $tooltip ) #nl @}
+			@{ self.$name.SetToolTip( $tooltip ) #nl @}
 
 			#ifnotnull $context_help
 			@{ self.$name.SetHelpText( $context_help ) #nl @}

--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -47,7 +47,7 @@
 class wxIndependentStatusBar : public wxStatusBar
 {
 public:
-	wxIndependentStatusBar( wxWindow *parent, wxWindowID id = wxID_ANY, long style = wxST_SIZEGRIP, const wxString& name = wxStatusBarNameStr )
+	wxIndependentStatusBar( wxWindow *parent, wxWindowID id = wxID_ANY, long style = wxSTB_SIZEGRIP, const wxString& name = wxStatusBarNameStr )
 	:
 	wxStatusBar( parent, id, style, name )
 	{
@@ -1767,7 +1767,7 @@ MACRO(wxRB_USE_CHECKBOX)
 #endif
 
 // wxStatusBar
-MACRO(wxST_SIZEGRIP)
+MACRO(wxSTB_SIZEGRIP)
 
 // wxMenuBar
 MACRO(wxMB_DOCKABLE)

--- a/wxfbTest/wxfbTest.fbp
+++ b/wxfbTest/wxfbTest.fbp
@@ -162,7 +162,7 @@ Created with wxFormBuilder by:
                 <property name="permission">protected</property>
                 <property name="pos"></property>
                 <property name="size"></property>
-                <property name="style">wxST_SIZEGRIP</property>
+                <property name="style">wxSTB_SIZEGRIP</property>
                 <property name="subclass"></property>
                 <property name="tooltip"></property>
                 <property name="window_extra_style"></property>

--- a/wxfbTest/wxfbTest_GUI.cpp
+++ b/wxfbTest/wxfbTest_GUI.cpp
@@ -60,7 +60,7 @@ MainFrame::MainFrame( wxWindow* parent, int id, wxString title, wxPoint pos, wxS
 	
 	this->SetMenuBar( m_menubar1 );
 	
-	m_statusBar1 = this->CreateStatusBar( 1, wxST_SIZEGRIP, ID_DEFAULT );
+	m_statusBar1 = this->CreateStatusBar( 1, wxSTB_SIZEGRIP, ID_DEFAULT );
 	m_toolBar1 = this->CreateToolBar( wxTB_HORIZONTAL, ID_DEFAULT ); 
 	m_toolBar1->AddTool( ID_DEFAULT, wxT("tool"), wxBitmap( copy_xpm ), wxNullBitmap, wxITEM_NORMAL, wxEmptyString, wxEmptyString );
 	m_toolBar1->AddTool( ID_DEFAULT, wxT("tool"), wxBitmap( cut_xpm ), wxNullBitmap, wxITEM_NORMAL, wxEmptyString, wxEmptyString );


### PR DESCRIPTION
I've made a couple changes to correct errors I was getting when using the generated python code. The python code works correctly now, but I'm not sure how to run the built in tests, or if this will effect other code generation. 

Warnings received:
wxPyDeprecationWarning: Call to deprecated item. Use SetToolTip instead.

AttributeError: module 'wx' has no attribute 'ST_SIZEGRIP'

Thanks,
Jim
