### PR TITLE
Added the ability to change if a subclass is forward declared or the header is included

### DIFF
--- a/output/xml/default.xml
+++ b/output/xml/default.xml
@@ -130,6 +130,7 @@
     <property name="subclass" type="parent" help="For easy use of custom widgets which are simple variations from standard ones, without requiring a new plugin for wxFB or a full xrc handler for wxWidgets. For C++, this replaces the name of the class. For XRC, this sets the subclass value on the object tag.">
 		<child name="name" help="The name of the subclass."/>
 		<child name="header" help="For C++ Only. The header to be included for the subclass."/>
+		<child name="forward_declare" type="bool" help="For C++ Only. Forward declare the subclass, otherwise include the header.">forward_declare</child>
 	</property>
 	<category name="wxKeyEvent" type="interface">
 		<event name="OnChar" class="wxKeyEvent" help="Process a wxEVT_CHAR event." />

--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -1271,7 +1271,15 @@ void CppCodeGenerator::GenSubclassSets( PObjectBase obj, std::set< wxString >* s
 			// No name, so do nothing
 			return;
 		}
-
+		
+		//check if user wants to include the header or forward declare
+		bool forward_declare = true;
+		std::map< wxString, wxString >::iterator forward_declare_it = children.find( wxT( "forward_declare" ) );
+		if ( children.end() != forward_declare_it )
+		{
+			forward_declare = forward_declare_it->second == wxT( "forward_declare" );
+		}
+		
 		//get namespaces
 		wxString originalValue = nameVal;
 		int delimiter = nameVal.Find( wxT( "::" ) ) ;
@@ -1340,7 +1348,8 @@ void CppCodeGenerator::GenSubclassSets( PObjectBase obj, std::set< wxString >* s
 
 		wxString include = wxT( "#include \"" ) + headerVal + wxT( "\"" );
 		if ( pkg->GetPackageName() == wxT( "Forms" ) ||
-			 obj->GetChild( 1, wxT("menu") ) )
+			 obj->GetChild( 1, wxT("menu") ) ||
+			 !forward_declare )
 		{
 			std::vector< wxString >::iterator it = std::find( headerIncludes->begin(), headerIncludes->end(), include );
 			if ( headerIncludes->end() == it )

--- a/src/model/database.cpp
+++ b/src/model/database.cpp
@@ -1212,6 +1212,10 @@ void ObjectDatabase::ParseProperties( ticpp::Element* elem_obj, PObjectInfo obj_
 				std::string child_description;
 				elem_child->GetAttributeOrDefault( DESCRIPTION_TAG, &child_description, "" );
 				child.m_description = _WXSTR( child_description );
+				
+				std::string child_type;
+				elem_child->GetAttributeOrDefault( "type", &child_type, "wxString" );
+				child.m_type = ParsePropertyType( _WXSTR( child_type ) );
 
 				// Get default value
 				try

--- a/src/model/objectbase.h
+++ b/src/model/objectbase.h
@@ -81,6 +81,7 @@ public:
 	wxString m_name;
 	wxString m_defaultValue;
 	wxString m_description;
+	PropertyType m_type;
 };
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Added the ability to change if a subclass is forward declared or the header is included in the generated file. The default is to forward declare it (previous behavior). This included allowing a child property to have a type. Currently only PT_BOOL and PT_WXSTRING are supported