### PR TITLE
Python CG: Make TreeListCtrl compatible with wxPython Phoenix

### DIFF
--- a/output/plugins/additional/xml/data.pythoncode
+++ b/output/plugins/additional/xml/data.pythoncode
@@ -125,14 +125,18 @@ Python code generation written by
   </templates>
 
   <templates class="wxTreeListCtrl">
-	<template name="construction">self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )</template>
-	<template name="evt_connect_OnTreelistSelectionChanged">self.$name.Bind( wx.EVT_TREELIST_SELECTION_CHANGED, #handler )</template>
-	<template name="evt_connect_OnTreelistItemExpanding">self.$name.Bind( wx.EVT_TREELIST_ITEM_EXPANDING, #handler )</template>
-	<template name="evt_connect_OnTreelistItemExpanded">self.$name.Bind( wx.EVT_TREELIST_ITEM_EXPANDED, #handler )</template>
-	<template name="evt_connect_OnTreelistItemChecked">self.$name.Bind( wx.EVT_TREELIST_ITEM_CHECKED, #handler )</template>
-	<template name="evt_connect_OnTreelistItemActivated">self.$name.Bind( wx.EVT_TREELIST_ITEM_ACTIVATED, #handler )</template>
-	<template name="evt_connect_OnTreelistItemContextMenu">self.$name.Bind( wx.EVT_TREELIST_ITEM_CONTEXT_MENU, #handler )</template>
-	<template name="evt_connect_OnTreelistColumnSorted">self.$name.Bind( wx.EVT_TREELIST_COLUMN_SORTED, #handler )</template>
+	<template name="declaration">#class* $name;</template>
+	<template name="include">import wx.dataview</template>
+	<template name="construction">
+        self.$name = wx.dataview.TreeListCtrl( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
+    </template>
+	<template name="evt_connect_OnTreelistSelectionChanged">self.$name.Bind( wx.dataview.EVT_TREELIST_SELECTION_CHANGED, #handler )</template>
+	<template name="evt_connect_OnTreelistItemExpanding">self.$name.Bind( wx.dataview.EVT_TREELIST_ITEM_EXPANDING, #handler )</template>
+	<template name="evt_connect_OnTreelistItemExpanded">self.$name.Bind( wx.dataview.EVT_TREELIST_ITEM_EXPANDED, #handler )</template>
+	<template name="evt_connect_OnTreelistItemChecked">self.$name.Bind( wx.dataview.EVT_TREELIST_ITEM_CHECKED, #handler )</template>
+	<template name="evt_connect_OnTreelistItemActivated">self.$name.Bind( wx.dataview.EVT_TREELIST_ITEM_ACTIVATED, #handler )</template>
+	<template name="evt_connect_OnTreelistItemContextMenu">self.$name.Bind( wx.dataview.EVT_TREELIST_ITEM_CONTEXT_MENU, #handler )</template>
+	<template name="evt_connect_OnTreelistColumnSorted">self.$name.Bind( wx.dataview.EVT_TREELIST_COLUMN_SORTED, #handler )</template>
   </templates>
 
   <templates class="wxTreeListCtrlColumn">

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -1705,6 +1705,13 @@ void PythonTemplateParser::SetupModulePrefixes()
 	ADD_PREDEFINED_PREFIX( wxDV_VERT_RULES, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDV_VARIABLE_LINE_HEIGHT, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDV_NO_HEADER, wx.dataview. );
+    
+    ADD_PREDEFINED_PREFIX( wxTL_SINGLE, wx.dataview. );
+	ADD_PREDEFINED_PREFIX( wxTL_MULTIPLE, wx.dataview. );
+	ADD_PREDEFINED_PREFIX( wxTL_CHECKBOX, wx.dataview. );
+	ADD_PREDEFINED_PREFIX( wxTL_3STATE, wx.dataview. );
+	ADD_PREDEFINED_PREFIX( wxTL_USER_3STATE, wx.dataview. );
+	ADD_PREDEFINED_PREFIX( wxTL_DEFAULT_STYLE, wx.dataview. );
 
 	ADD_PREDEFINED_PREFIX( wxDP_SPIN, wx.adv. );
 	ADD_PREDEFINED_PREFIX( wxDP_DROPDOWN, wx.adv. );


### PR DESCRIPTION
This mostly consists of adding the wx.dataview prefix. For reference see https://wxpython.org/Phoenix/docs/html/classic_vs_phoenix.html#classic-vs-phoenix for TreeListCtrl at the bottom of the page,