### PR TITLE
Fix application bundle creation on macOS to produce usable application

### DIFF
--- a/install/macosx/makedist.sh
+++ b/install/macosx/makedist.sh
@@ -33,7 +33,8 @@ FILES="-x $PROJECT_ROOT/output/wxFormBuilder.app/Contents/MacOS/wxformbuilder \
 -x $PLUG_IN_PATH/libadditional.dylib \
 -x $PLUG_IN_PATH/libcommon.dylib \
 -x $PLUG_IN_PATH/libcontainers.dylib \
--x $PLUG_IN_PATH/liblayout.dylib"
+-x $PLUG_IN_PATH/liblayout.dylib \
+-x $PLUG_IN_PATH/libforms.dylib"
 
 # these are 'old' contributions that were merged into the main 
 # wxWidgets repo after 2.9
@@ -51,3 +52,15 @@ if [ -f "$PLUG_IN_PATH/libwxadditions-mini.dylib" ]; then
 fi
 
 dylibbundler -od -b -d $PROJECT_ROOT/output/wxFormBuilder.app/Contents/libs/ $FILES
+
+#Work around the likely bug in dylibbundler leading in copying two exemplars of the same dylib with different names instead of creating symlinks or changing the dependency name in the depending binaries
+pushd $PROJECT_ROOT/output/wxFormBuilder.app/Contents/libs/
+wx_version="$(wx-config --version|cut -c1-3)"
+for lib in $(ls libwx_*.dylib); do
+  lib_basename="${lib%%\-*}"
+  if [[ "${lib}" != "${lib_basename}-${wx_version}.dylib" ]] && [ -f "${lib_basename}-${wx_version}.dylib" ]; then
+    rm -f "${lib_basename}-${wx_version}.dylib"
+    ln -sf "${lib}" "${lib_basename}-${wx_version}.dylib"
+  fi
+done
+popd > /dev/null


### PR DESCRIPTION
Fixes #340 
With these changes, the app bundle produced from travis builds should be actually usable without any manual modifications.
Might also be a fix for #313, although there is no useful info there.