### PR TITLE
force-wx-config option for automake is now optional, this is useful for custom wxWidgets builds.

### DIFF
--- a/build/premake/wxwidgets.lua
+++ b/build/premake/wxwidgets.lua
@@ -61,7 +61,7 @@ wxVersion         = _OPTIONS["wx-version"]
 wxUnicodeSign     = "u"
 wxUseMediaCtrl    = true
 wxUseUnicode      = true
-wxMonolithic      = true
+wxMonolithic      = false
 
 if not wxCompiler then wxCompiler = "gcc" end
 wxCompilerName = wxCompiler
@@ -221,7 +221,9 @@ function wx_config_Private(wxRoot, wxDebug, wxHost, wxVersion, wxStatic, wxUnico
 				links { "wxmsw"..libVersion..wxBuildType }
 			else
 				links { "wxbase"..libVersion..wxBuildType } -- base lib
-				for i, lib in ipairs(string.explode(wxLibs, ",")) do
+				local libs = "net,xml,adv,core,html,gl,aui,propgrid,ribbon,richtext,stc,webview,xrc"
+				if wxUseMediaCtrl then libs = libs .. ",media" end
+				for i, lib in ipairs(string.explode(libs, ",")) do
 					local libPrefix = 'wxmsw'
 					if lib == "xml" or lib == "net" or lib == "odbc" then
 						libPrefix = 'wxbase'

--- a/install/windows/wxFormBuilder.iss
+++ b/install/windows/wxFormBuilder.iss
@@ -66,18 +66,18 @@ Name: desktopicon; Description: {cm:CreateDesktopIcon}; GroupDescription: {cm:Ad
 [Files]
 #if defined UNICODE
 Source: ..\..\output\*; DestDir: {app}; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: .svn\*, *d.exe, *d.dll, wxmsw30ud_*, wxmsw30umd_*, Thumbs.db, *.a
-Source: C:\msys64\mingw32\bin\wx*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libstdc++*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libgcc*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libintl*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libexpat*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libjpeg*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libpng*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libtiff*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\zlib*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libwinpthread*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\libiconv*.dll; DestDir: {app}
-Source: C:\msys64\mingw32\bin\liblzma*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\wx*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libstdc++*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libgcc*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libintl*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libexpat*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libjpeg*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libpng*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libtiff*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\zlib*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libwinpthread*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\libiconv*.dll; DestDir: {app}
+Source: C:\msys32\mingw32\bin\liblzma*.dll; DestDir: {app}
 #else
 Source: files9x\*; DestDir: {app}; Flags: ignoreversion recursesubdirs createallsubdirs; Excludes: .svn\*, *d.exe, *d.dll, wxmsw28ud_*, wxmsw28umd_*, Thumbs.db, *.a
 #endif


### PR DESCRIPTION
it is now possible to build wxFormBuilder without the force-wx-config option.