### PR TITLE
Fix warnings

### DIFF
--- a/src/codegen/codewriter.cpp
+++ b/src/codegen/codewriter.cpp
@@ -37,6 +37,7 @@
 #include <wx/stc/stc.h>
 
 #include <cstring>
+#include <fstream>
 
 CodeWriter::CodeWriter()
 :

--- a/src/codegen/codewriter.cpp
+++ b/src/codegen/codewriter.cpp
@@ -206,13 +206,13 @@ void FileCodeWriter::WriteBuffer()
 	// Compare buffer with existing file (if any) to determine if
 	// writing the file is necessary
 	bool shouldWrite = true;
-	std::ifstream file( m_filename.mb_str( wxConvFile ), std::ios::binary | std::ios::in );
+	std::ifstream fileIn(m_filename.mb_str(wxConvFile), std::ios::binary | std::ios::in);
 
 	std::string buf;
 
-	if ( file )
+	if (fileIn)
 	{
-		MD5 diskHash( file );
+		MD5 diskHash(fileIn);
 		unsigned char* diskDigest = diskHash.raw_digest();
 
 		MD5 bufferHash;
@@ -238,21 +238,22 @@ void FileCodeWriter::WriteBuffer()
 
 	if ( shouldWrite )
 	{
-		wxFile file;
-		if ( !file.Create( m_filename, true ) )
+		wxFile fileOut;
+		if (!fileOut.Create(m_filename, true))
 		{
 			wxLogError( _("Unable to create file: %s"), m_filename.c_str() );
 			return;
 		}
 
-		if (m_useMicrosoftBOM) {
-			file.Write(MICROSOFT_BOM, 3);
+		if (m_useMicrosoftBOM)
+		{
+			fileOut.Write(MICROSOFT_BOM, 3);
 		}
 
 		if (!m_useUtf8)
-            file.Write( buf.c_str(), buf.length() );
-        else
-            file.Write( m_buffer );
+			fileOut.Write(buf.c_str(), buf.length());
+		else
+			fileOut.Write(m_buffer);
 	}
 }
 

--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -475,7 +475,7 @@ void LuaCodeGenerator::GenerateInheritedClass( PObjectBase userClasses, PObjectB
 					PObjectInfo obj_info = obj->GetObjectInfo();
 
 					wxString strClassName = wxT("");
-					wxString code = GenEventEntryForInheritedClass(obj, obj_info, templateName, handlerName, strClassName);
+					code = GenEventEntryForInheritedClass(obj, obj_info, templateName, handlerName, strClassName);
 
 					bool bAddCaption = false;
 					PProperty propName = obj->GetProperty( wxT("name") );
@@ -1271,9 +1271,9 @@ void LuaCodeGenerator::GenConstruction(PObjectBase obj, bool is_widget, wxString
 					sub2 = obj->GetChild(1)->GetChild(0);
 
 					wxString _template;
-					bool bSplitVertical = false;
 					wxString strMode = obj->GetProperty( wxT("splitmode") )->GetValue();
-					if ( (bSplitVertical = (strMode == wxT("wxSPLIT_VERTICAL"))) )
+					bool bSplitVertical = (strMode == wxT("wxSPLIT_VERTICAL"));
+					if (bSplitVertical)
 					{
 						_template = wxT("#utbl$name:SplitVertically( ");
 					}

--- a/src/md5/md5.cc
+++ b/src/md5/md5.cc
@@ -120,11 +120,11 @@ void MD5::update(const uint8_t* input, uint32_t input_length) {
 
 void MD5::update(FILE *file){
 
-  unsigned char buffer[1024];
-  int len;
+  unsigned char fileBuffer[1024];
+  size_t len;
 
-  while ((len=fread(buffer, 1, 1024, file)))
-    update(buffer, len);
+  while ((len=fread(fileBuffer, 1, 1024, file)))
+    update(fileBuffer, len);
 
   fclose (file);
 
@@ -140,13 +140,13 @@ void MD5::update(FILE *file){
 
 void MD5::update(istream& stream){
 
-  unsigned char buffer[1024];
-  int len;
+  unsigned char streamBuffer[1024];
+  std::streamsize len;
 
   while (stream.good()){
-    stream.read((char*)buffer, 1024); // note that return value of read is unusable.
+    stream.read((char*)streamBuffer, 1024); // note that return value of read is unusable.
     len=stream.gcount();
-    update(buffer, len);
+    update(streamBuffer, static_cast<unsigned int>(len));
   }
 
 }
@@ -161,13 +161,13 @@ void MD5::update(istream& stream){
 
 void MD5::update(ifstream& stream){
 
-  unsigned char buffer[1024];
-  int len;
+  unsigned char streamBuffer[1024];
+  std::streamsize len;
 
   while (stream.good()){
-    stream.read((char*)buffer, 1024); // note that return value of read is unusable.
+    stream.read((char*)streamBuffer, 1024); // note that return value of read is unusable.
     len=stream.gcount();
-    update(buffer, len);
+    update(streamBuffer, static_cast<unsigned int>(len));
   }
 
 }

--- a/src/md5/md5.cc
+++ b/src/md5/md5.cc
@@ -47,11 +47,8 @@ documentation and/or software.
 
 #include "md5.hh"
 
-#include <assert.h>
+#include <cassert>
 #include <cstring>
-#include <string>
-
-using namespace std;
 
 
 // MD5 simple initialization method
@@ -118,7 +115,7 @@ void MD5::update(FILE* file) {
 
 	assert(!finalized);
 
-	while ((len = fread(fileBuffer, 1, 1024, file)))
+	while ((len = std::fread(fileBuffer, 1, 1024, file)))
 		update(fileBuffer, static_cast<uint32_t>(len));
 }
 
@@ -130,7 +127,7 @@ void MD5::update(FILE* file) {
 // MD5 update for istreams.
 // Like update for files; see above.
 
-void MD5::update(istream& stream) {
+void MD5::update(std::istream& stream) {
 	char streamBuffer[1024];
 	std::streamsize len;
 
@@ -206,7 +203,7 @@ MD5::MD5(FILE* file) {
 
 
 
-MD5::MD5(istream& stream) {
+MD5::MD5(std::istream& stream) {
 	init(); // must be called by all constructors
 	update(stream);
 	finalize();

--- a/src/md5/md5.cc
+++ b/src/md5/md5.cc
@@ -57,9 +57,7 @@ using namespace std;
 // MD5 simple initialization method
 
 MD5::MD5(){
-
-  init();
-
+	init();
 }
 
 
@@ -114,15 +112,14 @@ void MD5::update(const unsigned char* input, uint32_t input_length) {
 // MD5 update for files.
 // Like above, except that it works on files (and uses above as a primitive.)
 
-void MD5::update(FILE *file){
-
-  unsigned char fileBuffer[1024];
-  size_t len;
+void MD5::update(FILE* file) {
+	unsigned char fileBuffer[1024];
+	size_t len;
 
 	assert(!finalized);
 
-  while ((len=fread(fileBuffer, 1, 1024, file)))
-    update(fileBuffer, static_cast<uint32_t>(len));
+	while ((len = fread(fileBuffer, 1, 1024, file)))
+		update(fileBuffer, static_cast<uint32_t>(len));
 }
 
 
@@ -133,18 +130,17 @@ void MD5::update(FILE *file){
 // MD5 update for istreams.
 // Like update for files; see above.
 
-void MD5::update(istream& stream){
-
-  char streamBuffer[1024];
-  std::streamsize len;
+void MD5::update(istream& stream) {
+	char streamBuffer[1024];
+	std::streamsize len;
 
 	assert(!finalized);
 
-  while (stream) {
-    stream.read(streamBuffer, 1024); // note that return value of read is unusable.
-    len=stream.gcount();
-    update(reinterpret_cast<unsigned char*>(streamBuffer), static_cast<uint32_t>(len));
-  }
+	while (stream) {
+		stream.read(streamBuffer, 1024); // note that return value of read is unusable.
+		len = stream.gcount();
+		update(reinterpret_cast<unsigned char*>(streamBuffer), static_cast<uint32_t>(len));
+	}
 
 }
 
@@ -159,8 +155,8 @@ void MD5::update(istream& stream){
 
 void MD5::finalize (){
 
-  uint8_t bits[8];
-  uint32_t index, padLen;
+	uint8_t bits[8];
+	uint32_t index, padLen;
 	static uint8_t PADDING[64] = {
     0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -187,14 +183,13 @@ void MD5::finalize (){
 	std::memset(buffer, 0, sizeof(*buffer));
 
   finalized=1;
-
 }
 
 
 
 
 MD5::MD5(const unsigned char* input, uint32_t input_length) {
-	init();  // must be called be all constructors
+	init(); // must be called by all constructors
 	update(input, input_length);
 	finalize();
 }
@@ -202,39 +197,37 @@ MD5::MD5(const unsigned char* input, uint32_t input_length) {
 
 
 
-MD5::MD5(FILE *file){
-
+MD5::MD5(FILE* file) {
 	init(); // must be called by all constructors
-  update(file);
-  finalize ();
+	update(file);
+	finalize();
 }
 
 
 
 
-MD5::MD5(istream& stream){
-
+MD5::MD5(istream& stream) {
 	init(); // must be called by all constructors
-  update (stream);
-  finalize();
+	update(stream);
+	finalize();
 }
 
 
 
 unsigned char* MD5::raw_digest() const {
-
-  unsigned char *s = new unsigned char[16];
+	unsigned char *s = new unsigned char[16];
 
 	assert(finalized);
 
 	std::memcpy(s, digest, 16);
-  return s;
+
+	return s;
 }
 
 
 
 char* MD5::hex_digest() const {
-  char *s= new char[33];
+	char *s= new char[33];
 
 	assert(finalized);
 
@@ -243,7 +236,7 @@ char* MD5::hex_digest() const {
 
   s[32]='\0';
 
-  return s;
+	return s;
 }
 
 
@@ -254,7 +247,8 @@ std::ostream& operator<<(std::ostream &stream, const MD5& context) {
 	char* hex = context.hex_digest();
 	stream << hex;
 	delete[] hex;
-  return stream;
+
+	return stream;
 }
 
 

--- a/src/md5/md5.cc
+++ b/src/md5/md5.cc
@@ -221,7 +221,7 @@ MD5::MD5(istream& stream){
 
 
 
-unsigned char *MD5::raw_digest(){
+unsigned char* MD5::raw_digest() const {
 
   unsigned char *s = new unsigned char[16];
 
@@ -233,7 +233,7 @@ unsigned char *MD5::raw_digest(){
 
 
 
-char *MD5::hex_digest(){
+char* MD5::hex_digest() const {
   char *s= new char[33];
 
 	assert(finalized);
@@ -250,9 +250,10 @@ char *MD5::hex_digest(){
 
 
 
-ostream& operator<<(ostream &stream, MD5 context){
-
-  stream << context.hex_digest();
+std::ostream& operator<<(std::ostream &stream, const MD5& context) {
+	char* hex = context.hex_digest();
+	stream << hex;
+	delete[] hex;
   return stream;
 }
 

--- a/src/md5/md5.hh
+++ b/src/md5/md5.hh
@@ -40,8 +40,8 @@ documentation and/or software.
 */
 #pragma once
 
-#include <stdio.h>
-#include <fstream>
+#include <cstdio>
+#include <istream>
 
 class MD5 {
 
@@ -50,14 +50,14 @@ public:
   MD5              ();  // simple initializer
   void  update     (const unsigned char* input, uint32_t input_length);
   void  update     (std::istream& stream);
-  void  update     (FILE* file);
+  void  update     (std::FILE* file);
   void  finalize   ();
 
 // constructors for special circumstances.  All these constructors finalize
 // the MD5 context.
   MD5              (const unsigned char* input, uint32_t input_length); // digest string, finalize
   MD5              (std::istream& stream);       // digest stream, finalize
-  MD5              (FILE* file);            // digest file, close, finalize
+  MD5              (std::FILE* file);            // digest file, close, finalize
 
 // methods to acquire finalized result
   unsigned char*    raw_digest () const;  // digest as a 16-byte binary array

--- a/src/md5/md5.hh
+++ b/src/md5/md5.hh
@@ -60,9 +60,9 @@ public:
   MD5              (FILE *file);            // digest file, close, finalize
 
 // methods to acquire finalized result
-  unsigned char    *raw_digest ();  // digest as a 16-byte binary array
-  char *            hex_digest ();  // digest as a 33-byte ascii-hex string
-  friend std::ostream&   operator<< (std::ostream&, MD5 context);
+  unsigned char*    raw_digest () const;  // digest as a 16-byte binary array
+  char*             hex_digest () const;  // digest as a 33-byte ascii-hex string
+  friend std::ostream& operator<<(std::ostream& stream, const MD5& context);
 
 
 

--- a/src/md5/md5.hh
+++ b/src/md5/md5.hh
@@ -42,7 +42,6 @@ documentation and/or software.
 
 #include <stdio.h>
 #include <fstream>
-#include <iostream>
 
 class MD5 {
 

--- a/src/md5/md5.hh
+++ b/src/md5/md5.hh
@@ -47,20 +47,18 @@ documentation and/or software.
 class MD5 {
 
 public:
-// methods for controlled operation:
+	// methods for controlled operation:
   MD5              ();  // simple initializer
-  void  update     (const unsigned char *input, unsigned int input_length);
+  void  update     (const unsigned char* input, uint32_t input_length);
   void  update     (std::istream& stream);
   void  update     (FILE *file);
-  void  update     (std::ifstream& stream);
   void  finalize   ();
 
 // constructors for special circumstances.  All these constructors finalize
 // the MD5 context.
-  MD5              (unsigned char *string); // digest string, finalize
+  MD5              (const unsigned char* input, uint32_t input_length); // digest string, finalize
   MD5              (std::istream& stream);       // digest stream, finalize
   MD5              (FILE *file);            // digest file, close, finalize
-  MD5              (std::ifstream& stream);      // digest stream, close, finalize
 
 // methods to acquire finalized result
   unsigned char    *raw_digest ();  // digest as a 16-byte binary array
@@ -80,8 +78,8 @@ private:
 
 	// last, the private methods, mostly static:
 	void init();                           // called by all constructors
-	void transform(const uint8_t* buffer); // does the real update work.  Note
-	                                       // that length is implied to be 64.
+	void transform(const uint8_t buffer[64]); // does the real update work.  Note
+	                                          // that length is implied to be 64.
 
 	static void encode(uint8_t* dest, const uint32_t* src, uint32_t length);
 	static void decode(uint32_t* dest, const uint8_t* src, uint32_t length);

--- a/src/md5/md5.hh
+++ b/src/md5/md5.hh
@@ -50,14 +50,14 @@ public:
   MD5              ();  // simple initializer
   void  update     (const unsigned char* input, uint32_t input_length);
   void  update     (std::istream& stream);
-  void  update     (FILE *file);
+  void  update     (FILE* file);
   void  finalize   ();
 
 // constructors for special circumstances.  All these constructors finalize
 // the MD5 context.
   MD5              (const unsigned char* input, uint32_t input_length); // digest string, finalize
   MD5              (std::istream& stream);       // digest stream, finalize
-  MD5              (FILE *file);            // digest file, close, finalize
+  MD5              (FILE* file);            // digest file, close, finalize
 
 // methods to acquire finalized result
   unsigned char*    raw_digest () const;  // digest as a 16-byte binary array

--- a/src/model/database.cpp
+++ b/src/model/database.cpp
@@ -317,16 +317,16 @@ PObjectBase ObjectDatabase::CreateObject( std::string classname, PObjectBase par
 			for (unsigned int i=0; !created && i < parentType->GetChildTypeCount(); i++)
 			{
 				PObjectType childType = parentType->GetChildType(i);
-				int max = childType->FindChildType(objType, aui);
+				int childMax = childType->FindChildType(objType, aui);
 
-				if (childType->IsItem() && max != 0)
+				if (childType->IsItem() && childMax != 0)
 				{
-					max = parentType->FindChildType(childType, aui);
+					childMax = parentType->FindChildType(childType, aui);
 
 					// si el tipo es un item y además el tipo del objeto a crear
 					// puede ser hijo del tipo del item vamos a intentar crear la
 					// instancia del item para crear el objeto como hijo de este
-					if (max < 0 || CountChildrenWithSameType(parent, childType) < max)
+					if (childMax < 0 || CountChildrenWithSameType(parent, childType) < childMax)
 					{
 						// No hay problemas para crear el item debajo de parent
 						PObjectBase item = NewObject(GetObjectInfo(childType->GetName()));
@@ -800,13 +800,13 @@ void ObjectDatabase::SetupPackage(const wxString& file,
 		ticpp::Element* elem_obj = root->FirstChildElement( OBJINFO_TAG, false );
 		while ( elem_obj )
 		{
-			std::string wxver;
-			elem_obj->GetAttributeOrDefault( WXVERSION_TAG, &wxver, "" );
-			if( wxver != "" )
+			std::string wxver_obj;
+			elem_obj->GetAttributeOrDefault(WXVERSION_TAG, &wxver_obj, "");
+			if (!wxver_obj.empty())
 			{
 				long wxversion = 0;
 				// skip widgets supported by higher wxWidgets version than used for the build
-				if( (! _WXSTR(wxver).ToLong( &wxversion ) ) || (wxversion > wxVERSION_NUMBER) )
+				if((!_WXSTR(wxver_obj).ToLong(&wxversion)) || (wxversion > wxVERSION_NUMBER))
 				{
 					elem_obj = elem_obj->NextSiblingElement( OBJINFO_TAG, false );
 					continue;

--- a/src/rad/inspector/objinspect.cpp
+++ b/src/rad/inspector/objinspect.cpp
@@ -265,10 +265,10 @@ wxPGProperty* ObjectInspector::GetProperty( PProperty prop )
 		wxPGChoices constants;
 		const std::map< wxString, wxString > options = opt_list->GetOptions();
 		std::map< wxString, wxString >::const_iterator it;
-		unsigned int i = 0;
+		unsigned int index = 0;
 		for( it = options.begin(); it != options.end(); ++it )
 		{
-			constants.Add( it->first, 1 << i++ );
+			constants.Add(it->first, 1 << index++);
 		}
 
 		int val = StringToBits(prop->GetValueAsString(), constants);
@@ -280,11 +280,11 @@ wxPGProperty* ObjectInspector::GetProperty( PProperty prop )
 		{
 			for ( size_t i = 0; i < flagsProp->GetItemCount(); i++ )
 			{
-				wxPGProperty* prop = flagsProp->Item( i );
-				std::map< wxString, wxString >::const_iterator option = options.find( prop->GetLabel() );
+				wxPGProperty* itemProp = flagsProp->Item(i);
+				std::map<wxString, wxString>::const_iterator option = options.find(itemProp->GetLabel());
 				if ( option != options.end() )
 				{
-					m_pg->SetPropertyHelpString( prop, option->second );
+					m_pg->SetPropertyHelpString(itemProp, option->second);
 				}
 			}
 		}
@@ -476,12 +476,12 @@ void ObjectInspector::AddItems( const wxString& name, PObjectBase obj,
 					std::list< PropertyChild >* children = prop_desc->GetChildren();
 					std::list< PropertyChild >::iterator it;
 					wxArrayString values = wxStringTokenize( prop->GetValueAsString(), wxT(";"), wxTOKEN_RET_EMPTY_ALL );
-					size_t i = 0;
+					size_t index = 0;
 					wxString value;
 
 					for ( it = children->begin(); it != children->end(); ++it )
 					{
-						if( values.GetCount() > i ) value = values[i++].Trim().Trim(false);
+						if (values.GetCount() > index) value = values[index++].Trim().Trim(false);
 						else value = wxT("");
 
 						wxPGProperty* child = nullptr;

--- a/src/rad/mainframe.cpp
+++ b/src/rad/mainframe.cpp
@@ -1003,12 +1003,11 @@ void MainFrame::UpdateFrame()
 
 void MainFrame::UpdateRecentProjects()
 {
-	int i, fi;
 	wxMenu *menuFile = GetMenuBar()->GetMenu( GetMenuBar()->FindMenu( wxT( "File" ) ) );
 
 	// borramos los items del menu de los projectos recientes
 
-	for ( i = 0 ; i < 4 ; i++ )
+	for (int i = 0 ; i < 4 ; i++)
 	{
 		if ( menuFile->FindItem( ID_RECENT_0 + i ) )
 			menuFile->Destroy( ID_RECENT_0 + i );
@@ -1021,13 +1020,13 @@ void MainFrame::UpdateRecentProjects()
 	}
 
 	// remove empty filenames and 'compress' the rest
-    fi = 0;
-	for ( i = 0 ; i < 4 ; i++ )
+    int fi = 0;
+	for (int i = 0 ; i < 4 ; i++)
 	{
 	    if(!m_recentProjects[i].IsEmpty())
 	        m_recentProjects[fi++] = m_recentProjects[i];
 	}
-	for ( i = fi ; i < 4 ; i++ )
+	for (int i = fi ; i < 4 ; i++)
         m_recentProjects[i] = wxT("");
 
     if ( !m_recentProjects[0].IsEmpty() )

--- a/src/utils/wxfbexception.h
+++ b/src/utils/wxfbexception.h
@@ -55,9 +55,9 @@ It will take care of the conversion	and throwing the exception.
 #define THROW_WXFBEX( message )																								\
 	{																														\
 	wxString hopefullyThisNameWontConflictWithOtherVariables;																\
-	wxString file( __FILE__, wxConvUTF8 );																					\
-	file = file.substr( file.find_last_of( wxT("\\/") ) + 1 );																\
-	hopefullyThisNameWontConflictWithOtherVariables << message << wxT(" <") << file << wxT("@");							\
+	wxString hopefullyUniqueFile(__FILE__, wxConvUTF8);																		\
+	hopefullyUniqueFile = hopefullyUniqueFile.substr(hopefullyUniqueFile.find_last_of(wxT("\\/")) + 1);						\
+	hopefullyThisNameWontConflictWithOtherVariables << message << wxT(" <") << hopefullyUniqueFile << wxT("@");				\
 	hopefullyThisNameWontConflictWithOtherVariables << wxString::Format( wxT("%i"), __LINE__ ) << wxT(">");					\
 	throw wxFBException( hopefullyThisNameWontConflictWithOtherVariables );													\
 	}


### PR DESCRIPTION
Fixes various warnings reported by MSVC 2015 except wxWidgets deprecation warnings which are handled by #417. Bigger rework of the MD5 class to prevent implicit type conversions.