### PR TITLE
Fixes LUA unique include filtering

### DIFF
--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -1060,10 +1060,6 @@ void LuaCodeGenerator::AddUniqueIncludes( const wxString& include, std::vector< 
 		line.Trim( false );
 		line.Trim( true );
 
-
-			includes->push_back( line );
-			continue;
-
 		// If it is an include, it must be unique to be written
 		std::vector< wxString >::iterator it = std::find( includes->begin(), includes->end(), line );
 		if ( includes->end() == it )


### PR DESCRIPTION
This fixes the issue #421. The solution was found by looking at the generated code, for some reason unique filtering accross different objects was working, only the filtering in a single object was affected. 