### PR TITLE
Fix garbage ico_size values

### DIFF
--- a/src/rad/inspector/wxfbadvprops.cpp
+++ b/src/rad/inspector/wxfbadvprops.cpp
@@ -688,7 +688,12 @@ void wxFBBitmapProperty::UpdateChildValues(const wxString& value)
 
 		if(childVals.Count() > 2)
 		{
-			Item(2)->SetValue( childVals[2]);
+			// This child requires a wxSize as data type, not a wxString
+			// The string format of a wxSize doesn't match the display format,
+			// convert it like ObjectInspector does
+			wxString aux = childVals[2];
+			aux.Replace(wxT(";"), wxT(","));
+			Item(2)->SetValue(WXVARIANT(TypeConv::StringToSize(aux)));
 		}
 	}
 	else if( childVals[0].Contains( _("Load From Art Provider") ) )


### PR DESCRIPTION
This fixes the root cause of #419 and #376. The reported crash probably happened because the preview tried to create an icon with these too big garbage values.