### PR TITLE
wxWidgets 3.1 fixups

### DIFF
--- a/output/plugins/additional/xml/additional.cppcode
+++ b/output/plugins/additional/xml/additional.cppcode
@@ -252,13 +252,18 @@ Written by
 	<template name="evt_connect_OnTextEnter">$name->Connect( wxEVT_COMMAND_TEXT_ENTER, #handler, NULL, this );</template>
   </templates>
 
-  <templates class="wxSpinCtrlDouble">
-    <template name="declaration">#class* $name;</template>
-    <template name="construction">$name = new #class( #wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} );</template>
-    <template name="include">@#include &lt;wx/spinctrl.h&gt;</template>
-	<template name="evt_entry_OnSpinCtrlDouble">EVT_SPINCTRLDOUBLE( $id, #handler )</template>
-	<template name="evt_connect_OnSpinCtrlDouble">$name->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, #handler, NULL, this );</template>
-  </templates>
+	<templates class="wxSpinCtrlDouble">
+		<template name="declaration">#class* $name;</template>
+		<template name="construction">$name = new #class( #wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} );</template>
+		<template name="settings">$name->SetDigits( $digits );</template>
+		<template name="include">@#include &lt;wx/spinctrl.h&gt;</template>
+		<template name="evt_entry_OnSpinCtrlDouble">EVT_SPINCTRLDOUBLE( $id, #handler )</template>
+		<template name="evt_connect_OnSpinCtrlDouble">$name->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, #handler, NULL, this );</template>
+		<template name="evt_entry_OnSpinCtrlText">EVT_TEXT( $id, #handler )</template>
+		<template name="evt_connect_OnSpinCtrlText">$name->Connect( wxEVT_COMMAND_TEXT_UPDATED, #handler, NULL, this );</template>
+		<template name="evt_entry_OnTextEnter">EVT_TEXT_ENTER( $id, #handler )</template>
+		<template name="evt_connect_OnTextEnter">$name->Connect( wxEVT_COMMAND_TEXT_ENTER, #handler, NULL, this );</template>
+	</templates>
 
   <templates class="wxSpinButton">
     <template name="declaration">#class* $name;</template>

--- a/output/plugins/additional/xml/additional.luacode
+++ b/output/plugins/additional/xml/additional.luacode
@@ -156,11 +156,13 @@ Lua code generation written by
 	<template name="evt_connect_OnTextEnter">#utbl$name:Connect( wx.wxEVT_COMMAND_TEXT_ENTER, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
   </templates>
 
-  <templates class="wxSpinCtrlDouble">
-	<template name="construction">#utbl$name = #class( #utbl#wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ +$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} )</template>
-	<template name="evt_connect_OnSpinCtrl">#utbl$name:Connect( wx.wxEVT_COMMAND_SPINCTRL_UPDATED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
-	<template name="evt_connect_OnSpinCtrlDouble">#utbl$name:Connect( wx.wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
-  </templates>
+	<templates class="wxSpinCtrlDouble">
+		<template name="construction">#utbl$name = #class( #utbl#wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ +$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} )</template>
+		<template name="settings">#utbl$name:SetDigits( $digits )</template>
+		<template name="evt_connect_OnSpinCtrlDouble">#utbl$name:Connect( wx.wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+		<template name="evt_connect_OnSpinCtrlText">#utbl$name:Connect( wx.wxEVT_COMMAND_TEXT_UPDATED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+		<template name="evt_connect_OnTextEnter">#utbl$name:Connect( wx.wxEVT_COMMAND_TEXT_ENTER, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+	</templates>
 
   <templates class="wxSpinButton">
 	<template name="construction">#utbl$name = #class( #utbl#wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ +$window_style @} #ifnotnull $window_name @{, $window_name @} )</template>

--- a/output/plugins/additional/xml/additional.phpcode
+++ b/output/plugins/additional/xml/additional.phpcode
@@ -174,10 +174,13 @@ PHP code generation written by
 	<template name="evt_connect_OnTextEnter">@$this->$name->Connect( wxEVT_COMMAND_TEXT_ENTER, #handler );</template>
   </templates>
 
-  <templates class="wxSpinCtrlDouble">
-	<template name="construction">@$this->$name = new #class( #wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} );</template>
-	<template name="evt_connect_OnSpinCtrlDouble">@$this->$name->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, #handler );</template>
-  </templates>
+	<templates class="wxSpinCtrlDouble">
+		<template name="construction">@$this->$name = new #class( #wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} );</template>
+		<template name="settings">@$this->$name->SetDigits( $digits );</template>
+		<template name="evt_connect_OnSpinCtrlDouble">@$this->$name->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, #handler );</template>
+		<template name="evt_connect_OnSpinCtrlText">@$this->$name->Connect( wxEVT_COMMAND_TEXT_UPDATED, #handler );</template>
+		<template name="evt_connect_OnTextEnter">@$this->$name->Connect( wxEVT_COMMAND_TEXT_ENTER, #handler );</template>
+	</templates>
 
   <templates class="wxSpinButton">
 	<template name="construction">@$this->$name = new #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, $window_name @} );</template>

--- a/output/plugins/additional/xml/additional.pythoncode
+++ b/output/plugins/additional/xml/additional.pythoncode
@@ -177,10 +177,13 @@ Python code generation written by
 	<template name="evt_connect_OnTextEnter">self.$name.Bind( wx.EVT_TEXT_ENTER, #handler )</template>
   </templates>
 
-  <templates class="wxSpinCtrlDouble">
-	<template name="construction">self.$name = #class( #wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} )</template>
-	<template name="evt_connect_OnSpinCtrlDouble">self.$name.Bind( wx.EVT_SPINCTRLDOUBLE, #handler )</template>
-  </templates>
+	<templates class="wxSpinCtrlDouble">
+		<template name="construction">self.$name = #class( #wxparent $name, $id, $value, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @}, $min, $max, $initial, $inc #ifnotnull $window_name @{, $window_name @} )</template>
+		<template name="settings">self.$name.SetDigits( $digits )</template>
+		<template name="evt_connect_OnSpinCtrlDouble">self.$name.Bind( wx.EVT_SPINCTRLDOUBLE, #handler )</template>
+		<template name="evt_connect_OnSpinCtrlText">self.$name.Bind( wx.EVT_TEXT, #handler )</template>
+		<template name="evt_connect_OnTextEnter">self.$name.Bind( wx.EVT_TEXT_ENTER, #handler )</template>
+	</templates>
 
   <templates class="wxSpinButton">
 	<template name="construction">self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, $window_name @} )</template>

--- a/output/plugins/additional/xml/additional.xml
+++ b/output/plugins/additional/xml/additional.xml
@@ -293,22 +293,29 @@ Written by
 	<event name="OnTextEnter" class="wxCommandEvent" help="Respond to a wxEVT_COMMAND_TEXT_ENTER event, generated when enter is pressed in the edit part of the spin control (which must have wxTE_PROCESS_ENTER style for this event to be generated)." />
 </objectinfo>
 
-<objectinfo class="wxSpinCtrlDouble" icon="spin_ctrl_double.xpm" type="widget">
-    <inherits class="wxWindow" />
-    <inherits class="AUI" />
+  <objectinfo class="wxSpinCtrlDouble" icon="spin_ctrl_double.xpm" type="widget">
+    <inherits class="wxWindow"/>
+    <inherits class="AUI"/>
     <property name="name" type="text">m_spinCtrlDouble</property>
     <property name="value" type="wxString"></property>
     <property name="min" type="float"     help="Minimal value.">0</property>
     <property name="max" type="float"     help="Maximal value.">100</property>
-	<property name="initial" type="float" help="Initial value.">0</property>
-	<property name="inc" type="float"     help="Increment value.">1</property>
+    <property name="initial" type="float" help="Initial value.">0</property>
+    <property name="inc" type="float"     help="Increment value.">1</property>
+    <property name="digits" type="uint"   help="The number of digits in the display.">0</property>
     <property name="style" type="bitlist">
-        <option name="wxSP_ARROW_KEYS"     help="The user can use arrow keys to change the value." />
-        <option name="wxSP_WRAP"           help="The value wraps at the minimum and maximum." />
-		wxSP_ARROW_KEYS
-	</property>
+      <option name="wxSP_ARROW_KEYS"           help="The user can use arrow keys to change the value."/>
+      <option name="wxSP_WRAP"                 help="The value wraps at the minimum and maximum."/>
+      <option name="wxTE_PROCESS_ENTER"        help="The control will generate the event wxEVT_COMMAND_TEXT_ENTER (otherwise pressing Enter key is either processed internally by the control or used for navigation between dialog controls)."/>
+      <option name="wxALIGN_LEFT"              help="Same as wxTE_LEFT for wxTextCtrl: the text is left aligned."/>
+      <option name="wxALIGN_CENTER_HORIZONTAL" help="Same as wxTE_CENTRE for wxTextCtrl: the text is centered."/>
+      <option name="wxALIGN_RIGHT"             help="Same as wxTE_RIGHT for wxTextCtrl: the text is right aligned (this is the default)."/>
+      wxSP_ARROW_KEYS
+    </property>
     <event name="OnSpinCtrlDouble" class="wxSpinDoubleEvent" help="Generated whenever the numeric value of the control is updated." />
-</objectinfo>
+    <event name="OnSpinCtrlText" class="wxCommandEvent" help="Generated whenever the user modifies the text in the edit part of the spin control directly."/>
+    <event name="OnTextEnter" class="wxCommandEvent" help="Respond to a wxEVT_COMMAND_TEXT_ENTER event, generated when enter is pressed in the edit part of the spin control (which must have wxTE_PROCESS_ENTER style for this event to be generated)."/>
+  </objectinfo>
 
 <objectinfo class="wxSpinButton" icon="spinbtn.xpm" type="widget">
     <inherits class="wxWindow" />

--- a/output/plugins/containers/xml/containers.phpcode
+++ b/output/plugins/containers/xml/containers.phpcode
@@ -207,6 +207,12 @@ PHP code generation written by
 		<template name="evt_connect_OnAuiNotebookEndDrag">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_END_DRAG, #handler );</template>
 		<template name="evt_connect_OnAuiNotebookDragMotion">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_DRAG_MOTION, #handler );</template>
 		<template name="evt_connect_OnAuiNotebookAllowDND">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_ALLOW_DND, #handler );</template>
+		<template name="evt_connect_OnAuiNotebookDragDone">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_DRAG_DONE, #handler );</template>
+		<template name="evt_connect_OnAuiNotebookTabMiddleDown">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_TAB_MIDDLE_DOWN, #handler );</template>
+		<template name="evt_connect_OnAuiNotebookTabMiddleUp">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_TAB_MIDDLE_UP, #handler );</template>
+		<template name="evt_connect_OnAuiNotebookTabRightDown">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_TAB_RIGHT_DOWN, #handler );</template>
+		<template name="evt_connect_OnAuiNotebookTabRightUp">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_TAB_RIGHT_UP, #handler );</template>
+		<template name="evt_connect_OnAuiNotebookBGDClick">@$this->$name->Connect( wxEVT_COMMAND_AUINOTEBOOK_BG_DCLICK, #handler );</template>
 	</templates>
 
 	<templates class="auinotebookpage">

--- a/output/plugins/containers/xml/containers.xml
+++ b/output/plugins/containers/xml/containers.xml
@@ -133,15 +133,21 @@ Written by
 		</property>
 		<property name="tab_ctrl_height" type="int" help="Sets the tab height. By default, the tab control height is calculated by measuring the text height and bitmap sizes on the tab captions. Calling this method will override that calculation and set the tab control to the specified height parameter. A call to this method will override any call to SetUniformBitmapSize(). Specifying -1 as the height will return the control to its default auto-sizing behaviour.">-1</property>
 		<property name="uniform_bitmap_size" type="wxSize" help="SetUniformBitmapSize() ensures that all tabs will have the same height, even if some tabs don't have bitmaps. Passing wxDefaultSize to this function will instruct the control to use dynamic tab height, which is the default behaviour. Under the default behaviour, when a tab with a large bitmap is added, the tab control's height will automatically increase to accommodate the larger bitmap."/>
-		<event name="OnAuiNotebookPageClose" class="wxAuiNotebookEvent" help="The page is about to close." />
-		<event name="OnAuiNotebookPageClosed" class="wxAuiNotebookEvent" help="The page was closed." />
-		<event name="OnAuiNotebookPageChanged" class="wxAuiNotebookEvent" help="The page selection was changed."/>
-		<event name="OnAuiNotebookPageChanging" class="wxAuiNotebookEvent" help="The page selection is changing."/>
-		<event name="OnAuiNotebookButton" class="wxAuiNotebookEvent" help=""/>
-		<event name="OnAuiNotebookBeginDrag" class="wxAuiNotebookEvent" help=""/>
-		<event name="OnAuiNotebookEndDrag" class="wxAuiNotebookEvent" help=""/>
-		<event name="OnAuiNotebookDragMotion" class="wxAuiNotebookEvent" help=""/>
-		<event name="OnAuiNotebookAllowDND" class="wxAuiNotebookEvent" help="This event must be overridden to allow drag'n'drop among wxAuiNotebooks."/>
+		<event name="OnAuiNotebookPageClose" class="wxAuiNotebookEvent" help="A page is about to be closed. Processes a wxEVT_AUINOTEBOOK_PAGE_CLOSE event."/>
+		<event name="OnAuiNotebookPageClosed" class="wxAuiNotebookEvent" help="A page has been closed. Processes a wxEVT_AUINOTEBOOK_PAGE_CLOSED event."/>
+		<event name="OnAuiNotebookPageChanged" class="wxAuiNotebookEvent" help="The page selection was changed. Processes a wxEVT_AUINOTEBOOK_PAGE_CHANGED event."/>
+		<event name="OnAuiNotebookPageChanging" class="wxAuiNotebookEvent" help="The page selection is about to be changed. Processes a wxEVT_AUINOTEBOOK_PAGE_CHANGING event. This event can be vetoed."/>
+		<event name="OnAuiNotebookButton" class="wxAuiNotebookEvent" help="The window list button has been pressed. Processes a wxEVT_AUINOTEBOOK_BUTTON event."/>
+		<event name="OnAuiNotebookBeginDrag" class="wxAuiNotebookEvent" help="Dragging is about to begin. Processes a wxEVT_AUINOTEBOOK_BEGIN_DRAG event."/>
+		<event name="OnAuiNotebookEndDrag" class="wxAuiNotebookEvent" help="Dragging has ended. Processes a wxEVT_AUINOTEBOOK_END_DRAG event."/>
+		<event name="OnAuiNotebookDragMotion" class="wxAuiNotebookEvent" help="Emitted during a drag and drop operation. Processes a wxEVT_AUINOTEBOOK_DRAG_MOTION event."/>
+		<event name="OnAuiNotebookAllowDND" class="wxAuiNotebookEvent" help="Whether to allow a tab to be dropped. Processes a wxEVT_AUINOTEBOOK_ALLOW_DND event. This event must be specially allowed."/>
+		<event name="OnAuiNotebookDragDone" class="wxAuiNotebookEvent" help="Notify that the tab has been dragged. Processes a wxEVT_AUINOTEBOOK_DRAG_DONE event."/>
+		<event name="OnAuiNotebookTabMiddleDown" class="wxAuiNotebookEvent" help="The middle mouse button is pressed on a tab. Processes a wxEVT_AUINOTEBOOK_TAB_MIDDLE_DOWN event."/>
+		<event name="OnAuiNotebookTabMiddleUp" class="wxAuiNotebookEvent" help="The middle mouse button is released on a tab. Processes a wxEVT_AUINOTEBOOK_TAB_MIDDLE_UP event."/>
+		<event name="OnAuiNotebookTabRightDown" class="wxAuiNotebookEvent" help="The right mouse button is pressed on a tab. Processes a wxEVT_AUINOTEBOOK_TAB_RIGHT_DOWN event."/>
+		<event name="OnAuiNotebookTabRightUp" class="wxAuiNotebookEvent" help="The right mouse button is released on a tab. Processes a wxEVT_AUINOTEBOOK_TAB_RIGHT_UP event."/>
+		<event name="OnAuiNotebookBGDClick" class="wxAuiNotebookEvent" help="Double clicked on the tabs background area. Processes a wxEVT_AUINOTEBOOK_BG_DCLICK event."/>
 	</objectinfo>
 
 	<objectinfo class="auinotebookpage" icon="auinotebook.xpm" type="auinotebookpage">

--- a/plugins/additional/additional.cpp
+++ b/plugins/additional/additional.cpp
@@ -660,6 +660,8 @@ public:
 			obj->GetPropertyAsFloat(_("initial")),
 			obj->GetPropertyAsFloat(_("inc")));
 
+		window->SetDigits(obj->GetPropertyAsInteger(_("digits")));
+
 		window->Connect( wxEVT_COMMAND_SPINCTRLDOUBLE_UPDATED, wxSpinEventHandler( SpinCtrlDoubleComponent::OnSpin ), NULL, this );
 		return window;
 	}
@@ -694,6 +696,7 @@ public:
 		xrc.AddProperty(_("min"),_("min"), XRC_TYPE_INTEGER);
 		xrc.AddProperty(_("max"),_("max"), XRC_TYPE_INTEGER);
 		xrc.AddProperty(_("inc"),_("inc"), XRC_TYPE_FLOAT);
+		xrc.AddProperty(_("digits"), _("digits"), XRC_TYPE_INTEGER);
 		return xrc.GetXrcObject();
 	}
 
@@ -706,6 +709,7 @@ public:
 		filter.AddProperty(_("min"),_("min"), XRC_TYPE_INTEGER);
 		filter.AddProperty(_("max"),_("max"), XRC_TYPE_INTEGER);
 		filter.AddProperty(_("inc"),_("inc"), XRC_TYPE_FLOAT);
+		filter.AddProperty(_("digits"), _("digits"), XRC_TYPE_INTEGER);
 
 		return filter.GetXfbObject();
 	}


### PR DESCRIPTION
Some functional changes got lost during stripping the formatting of my original patch from #211 for the PR #417 which this PR restores. There are still at least some updated help messages lost but it is quite some work to restore these and without set formatting rules i am unsure how to restore these without introducing unwanted formatting changes.

Additionally this PR includes a slightly improved version of my patch from #415.