### PR TITLE
Add support to use arrays as names of objects

### DIFF
--- a/output/xml/default.xml
+++ b/output/xml/default.xml
@@ -22,6 +22,7 @@
 	<property name="internationalize" type="bool" help="For C++ Only.&#x0A;Generate strings with _() macro instead of wxT() macro. This allows for translation.">0</property>
 	<category name="C++ Properties">
 		<property name="use_enum" type="bool" help="For C++ Only.&#x0A;Generate an enumeration for control IDs instead of a list of #defines">0</property>
+      <property name="use_array_enum" type="bool" help="For C++ Only.&#x0A;Generate an enumeration for the dimensions of arrays">0</property>
 		<property name="use_microsoft_bom" type="bool" help="For C++ and WXMSW Only.&#x0A;Files are generated with UTF-8 encoding. Microsoft compiliers expect a specific byte sequence at the beginning of a file. GCC does NOT expect this. Only set this to true when using a Microsoft compiler.">0</property>
 		<property name="precompiled_header" type="text" help="For C++ Only.&#x0A;The exact code to be generated at the top of the source file to support precompiled headers. For example, to include wxprec.h, the value of this property should be:&#x0A;#include &lt;wx/wxprec.h&gt;"/>
 		<property name="class_decoration" type="parent" help="For C++ Only.&#x0A;Used to decorate classes with DLL export macros.">

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -47,6 +47,9 @@ m_indent( 0 )
 {
 }
 
+TemplateParser::~TemplateParser() = default;
+
+
 TemplateParser::Token TemplateParser::GetNextToken()
 {
 	// There are 3 special characters
@@ -191,7 +194,7 @@ wxString TemplateParser::ParsePropertyName( wxString* child )
 	// property names used in templates may be encapsulated by curly brackets (e.g. ${name}) so they
     // can be surrounded by the template content without any white spaces now.
 	bool foundLeftCurlyBracket = false;
-	bool saveChild = ( NULL != child );
+	bool saveChild = (!!child);
 
 	if (!m_in.Eof())
 	{
@@ -244,7 +247,7 @@ bool TemplateParser::ParseProperty()
 	wxString propname = ParsePropertyName( &childName );
 
 	PProperty property = m_obj->GetProperty(propname);
-	if ( NULL == property.get() )
+	if (!property)
 	{
 		wxLogError( wxT("The property '%s' does not exist for objects of class '%s'"), propname.c_str(), m_obj->GetClassName().c_str() );
 		return true;
@@ -519,7 +522,7 @@ bool TemplateParser::ParseForEach()
 
 PProperty TemplateParser::GetProperty( wxString* childName )
 {
-	PProperty property( (Property*)NULL );
+	PProperty property;
 
 	// Check for #wxparent, #parent, or #child
 	if ( GetNextToken() == TOK_MACRO )
@@ -987,7 +990,7 @@ wxString TemplateParser::ParseTemplate()
                 ParseText();
                 break;
             default:
-                return wxT("");
+                return wxEmptyString;
             }
         }
     }
@@ -1066,16 +1069,20 @@ wxString TemplateParser::ExtractInnerTemplate()
 
 bool TemplateParser::ParsePred()
 {
-	if (m_pred != wxT("") )
+	if (!m_pred.empty())
+	{
 		m_out << m_pred;
+	}
 
 	return true;
 }
 
 bool TemplateParser::ParseNPred()
 {
-	if (m_npred != wxT("") )
+	if (!m_npred.empty())
+	{
 		m_out << m_npred;
+	}
 
 	return true;
 }
@@ -1177,6 +1184,9 @@ bool TemplateParser::IsEqual(const wxString& value, const wxString& set)
 }
 
 
+
+
+CodeGenerator::~CodeGenerator() = default;
 
 
 void CodeGenerator::FindArrayObjects(PObjectBase obj, ArrayItems& arrays, bool skipRoot)

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -406,14 +406,16 @@ bool TemplateParser::ParseForm()
 
 void TemplateParser::ParseLuaTable()
 {
-	PObjectBase project = PObjectBase(new ObjectBase(*AppData()->GetProjectData()));
-	PProperty propNs= project->GetProperty( wxT( "ui_table" ) );
-	if ( propNs )
+	const auto& project = AppData()->GetProjectData();
+	const auto& table = project->GetProperty(wxT("ui_table"));
+	if (table)
 	{
-		wxString strTableName = propNs->GetValueAsString();
-		if(strTableName.length() <= 0)
+		auto strTableName = table->GetValueAsString();
+		if (strTableName.empty())
+		{
 			strTableName = wxT("UI");
-		m_out <<strTableName + wxT(".");
+		}
+		m_out << strTableName << wxT(".");
 	}
 }
 

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -35,6 +35,9 @@
 #include "../model/types.h"
 #include "../utils/wxfbdefs.h"
 
+#include <map>
+#include <vector>
+
 #include <wx/sstream.h>
 
 /**
@@ -274,6 +277,28 @@ protected:
 
 public:
 	/**
+	* Describes the properties and state of an array item
+	*/
+	struct ArrayItem
+	{
+		/**
+		* Maximum used index for each array dimension
+		*/
+		std::vector<size_t> maxIndex;
+		/**
+		* State if the code generator has already declared this array
+		*/
+		bool isDeclared = false;
+	};
+	/**
+	* Lookup map of array items
+	*
+	* key = basename of the array
+	* value = properties and state of the array
+	*/
+	typedef std::map<wxString, ArrayItem> ArrayItems;
+
+	/**
 	* Virtual destructor.
 	*/
 	virtual ~CodeGenerator() {};
@@ -281,6 +306,19 @@ public:
 	* Generate the code of the project
 	*/
 	virtual bool GenerateCode( PObjectBase project ) = 0;
+
+	/**
+	* Stores all discovered arrays for the given object and its child objects.
+	*/
+	void FindArrayObjects(PObjectBase obj, ArrayItems& arrays, bool skipRoot = false);
+
+	/**
+	* Parses a name and determines if it is an array.
+	*
+	* Returns true if it is an array and extracts the basename and the indexes of the dimensions.
+	* Returns false if it is not.
+	*/
+	bool ParseArrayName(const wxString& name, wxString& baseName, ArrayItem& item);
 };
 
 

--- a/src/codegen/codegen.h
+++ b/src/codegen/codegen.h
@@ -144,7 +144,7 @@ private:
 	Ident SearchIdent(wxString ident);
 	Ident ParseIdent();
 
-	wxString ParsePropertyName( wxString* child = NULL );
+	wxString ParsePropertyName(wxString* child = nullptr);
 	/**
 	* This routine extracts the source code from a template enclosed between
 	* the #begin and #end macros, having in mind that they can be nested
@@ -189,7 +189,7 @@ private:
 	bool ParseIfTypeNotEqual();
 	void ParseLuaTable();
 
-	PProperty GetProperty( wxString* childName = NULL );
+	PProperty GetProperty(wxString* childName = nullptr);
 	PObjectBase GetWxParent();
 	PProperty GetRelatedProperty( PObjectBase relative );
 
@@ -227,7 +227,7 @@ public:
 	*/
 	virtual PTemplateParser CreateParser( const TemplateParser* oldparser, wxString _template ) = 0;
 
-	virtual ~TemplateParser() {};
+	virtual ~TemplateParser();
 
 	/**
 	* Returns the code for a "wxWindow *parent" root attribute' name.
@@ -301,7 +301,7 @@ public:
 	/**
 	* Virtual destructor.
 	*/
-	virtual ~CodeGenerator() {};
+	virtual ~CodeGenerator();
 	/**
 	* Generate the code of the project
 	*/

--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -67,7 +67,7 @@ wxString CppTemplateParser::RootWxParentToCode()
 PTemplateParser CppTemplateParser::CreateParser( const TemplateParser* oldparser, wxString _template )
 {
 	const CppTemplateParser* cppOldParser = dynamic_cast< const CppTemplateParser* >( oldparser );
-	if ( cppOldParser != NULL )
+	if (cppOldParser)
 	{
 		PTemplateParser newparser( new CppTemplateParser( *cppOldParser, _template ) );
 		return newparser;
@@ -539,7 +539,7 @@ void CppCodeGenerator::GenerateInheritedClass( PObjectBase userClasses, PObjectB
 	}
 	else
 	{
-		m_header->WriteLn(wxT(""));
+		m_header->WriteLn(wxEmptyString);
 	}
 
 	m_header->Unindent();
@@ -617,7 +617,7 @@ bool CppCodeGenerator::GenerateCode( PObjectBase project )
 	}
 
 	m_header->WriteLn(wxT("#pragma once"));
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 
 	code = GetCode( project, wxT( "header_preamble" ) );
 	if ( !code.empty() )
@@ -640,7 +640,7 @@ bool CppCodeGenerator::GenerateCode( PObjectBase project )
 	}
 	if ( !subclasses.empty() )
 	{
-		m_header->WriteLn( wxT( "" ) );
+		m_header->WriteLn(wxEmptyString);
 	}
 
 	// Generating in the .h header file those include from components dependencies.
@@ -655,7 +655,7 @@ bool CppCodeGenerator::GenerateCode( PObjectBase project )
 	}
 	if ( !headerIncludes.empty() )
 	{
-		m_header->WriteLn( wxT( "" ) );
+		m_header->WriteLn(wxEmptyString);
 	}
 
 	// class decoration
@@ -884,7 +884,7 @@ bool CppCodeGenerator::GenEventEntry( PObjectBase obj, PObjectInfo obj_info, con
 	PCodeInfo code_info = obj_info->GetCodeInfo( wxT( "C++" ) );
 	if ( code_info )
 	{
-		_template = code_info->GetTemplate( wxString::Format( wxT( "evt_%s%s" ), disconnect ? wxT( "dis" ) : wxT( "" ), templateName.c_str() ) );
+		_template = code_info->GetTemplate(wxString::Format(wxT("evt_%s%s"), disconnect ? wxT("dis") : wxEmptyString, templateName.c_str()));
 		if ( disconnect && _template.empty() )
 		{
 			_template = code_info->GetTemplate( wxT( "evt_" ) + templateName );
@@ -1085,7 +1085,7 @@ wxString CppCodeGenerator::GetCode( PObjectBase obj, wxString name )
 		wxString msg( wxString::Format( wxT( "Missing \"%s\" template for \"%s\" class. Review your XML object description" ),
 										name.c_str(), obj->GetClassName().c_str() ) );
 		wxLogError( msg );
-		return wxT( "" );
+		return wxEmptyString;
 	}
 
 	_template = code_info->GetTemplate( name );
@@ -1221,7 +1221,7 @@ void CppCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool use_enum,
 	}
 
 	m_header->Unindent();
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 
 	// protected
 	m_header->WriteLn( wxT( "protected:" ) );
@@ -1249,7 +1249,7 @@ void CppCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool use_enum,
 	}
 	else if ( 0 == eventHandlerKind.compare( wxT( "decl" ) ) )
 	{
-		eventHandlerPrefix = wxT( "" );
+		eventHandlerPrefix = wxEmptyString;
 		eventHandlerPostfix = wxT( ";" );
 	}
 	else // Default: impl_virtual
@@ -1261,7 +1261,7 @@ void CppCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool use_enum,
 	GenVirtualEventHandlers( events, eventHandlerPrefix, eventHandlerPostfix );
 
 	m_header->Unindent();
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 
 	// public
 	m_header->WriteLn( wxT( "public:" ) );
@@ -1270,7 +1270,7 @@ void CppCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool use_enum,
 
 	// Validators' variables
 	GenValidatorVariables( class_obj );
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 
 	// The constructor is also included within public
 	m_header->WriteLn( GetCode( class_obj, wxT( "cons_decl" ) ) );
@@ -1280,11 +1280,11 @@ void CppCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool use_enum,
 
 	GetGenEventHandlers( class_obj );
 	m_header->Unindent();
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 
 	m_header->Unindent();
 	m_header->WriteLn( wxT( "};" ) );
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 }
 
 void CppCodeGenerator::GenEnumIds( PObjectBase class_obj )
@@ -1935,7 +1935,7 @@ void CppCodeGenerator::GenDefines( PObjectBase project )
 		id++;
 	}
 
-	m_header->WriteLn( wxT( "" ) );
+	m_header->WriteLn(wxEmptyString);
 }
 
 void CppCodeGenerator::GenSettings( PObjectInfo info, PObjectBase obj )
@@ -2122,13 +2122,18 @@ void CppCodeGenerator::FindEmbeddedBitmapProperties( PObjectBase obj, std::set<w
 
 void CppCodeGenerator::UseRelativePath( bool relative, wxString basePath )
 {
-	bool result;
 	m_useRelativePath = relative;
 
-	if ( m_useRelativePath )
+	if (m_useRelativePath)
 	{
-		result = wxFileName::DirExists( basePath );
-		m_basePath = ( result ? basePath : wxT( "" ) );
+		if (wxFileName::DirExists(basePath))
+		{
+			m_basePath = basePath;
+		}
+		else
+		{
+			m_basePath = wxEmptyString;
+		}
 	}
 }
 /*

--- a/src/codegen/cppcg.h
+++ b/src/codegen/cppcg.h
@@ -79,6 +79,7 @@ private:
 	PCodeWriter m_source;
 
 	bool m_useRelativePath;
+	bool m_useArrayEnum;
 	bool m_i18n;
 	wxString m_basePath;
 	unsigned int m_firstID;
@@ -96,6 +97,13 @@ private:
 	* Given an object and the name for a template, obtains the code.
 	*/
 	wxString GetCode( PObjectBase obj, wxString name);
+
+	/**
+	* Gets the declaration fragment for the specified object.
+	*
+	* This method encapsulates the adjustments that need to be made for array declarations.
+	*/
+	wxString GetDeclaration(PObjectBase obj, ArrayItems& arrays, bool useEnum);
 
 	/**
 	* Stores the project's objects classes set, for generating the includes.
@@ -121,7 +129,7 @@ private:
 	/**
 	* Generates classes declarations inside the header file.
 	*/
-	void GenClassDeclaration( PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector &events );
+	void GenClassDeclaration(PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector &events, ArrayItems& arrays);
 
 	/**
 	* Generates the event table.
@@ -136,7 +144,7 @@ private:
 	/**
 	* Recursive function for the attributes declaration, used inside GenClassDeclaration.
 	*/
-	void GenAttributeDeclaration( PObjectBase obj, Permission perm);
+	void GenAttributeDeclaration(PObjectBase obj, Permission perm, ArrayItems& arrays);
 
 	/**
 	* Recursive function for the validators' variables declaration, used inside GenClassDeclaration.
@@ -188,7 +196,7 @@ private:
 	/**
 	* Generates the constructor for a class
 	*/
-	void GenConstructor( PObjectBase class_obj, const EventVector &events );
+	void GenConstructor(PObjectBase class_obj, const EventVector &events, ArrayItems& arrays);
 
 	/**
 	* Generates the destructor for a class
@@ -199,7 +207,7 @@ private:
 	* Makes the objects construction, setting up the objects' and Layout properties.
 	* The algorithm is simmilar to that used in the designer preview generation.
 	*/
-	void GenConstruction( PObjectBase obj, bool is_widget );
+	void GenConstruction(PObjectBase obj, bool is_widget, ArrayItems& arrays);
 
 	/**
 	* Makes the objects destructions.

--- a/src/codegen/cppcg.h
+++ b/src/codegen/cppcg.h
@@ -39,6 +39,7 @@ The value of all properties that are file or a directory paths must be absolute,
 #include "codeparser.h"
 
 #include <set>
+#include <vector>
 
 /**
 * Parse the C++ templates.
@@ -282,7 +283,7 @@ public:
 	* @note path is generated with the separators, '/', since on Windows
 	*		the compilers interpret path correctly.
 	*/
-	void UseRelativePath( bool relative = false, wxString basePath = wxString() );
+	void UseRelativePath(bool relative = false, wxString basePath = wxEmptyString);
 
 	/**
 	* Set the First ID used during Code Generation.

--- a/src/codegen/luacg.h
+++ b/src/codegen/luacg.h
@@ -42,7 +42,9 @@ none
 
 #include "codegen.h"
 
+#include <map>
 #include <set>
+#include <vector>
 
 /**
 * Parse the Lua templates.
@@ -100,7 +102,7 @@ private:
 	/**
 	* Given an object and the name for a template, obtains the code.
 	*/
-	wxString GetCode( PObjectBase obj, wxString name, bool silent = false, wxString strSelf = wxT(""));
+	wxString GetCode(PObjectBase obj, wxString name, bool silent = false, wxString strSelf = wxEmptyString);
 
 	/**
 	* Gets the construction fragment for the specified object.
@@ -233,7 +235,7 @@ public:
 	* @note path is generated with the separators, '/', since on Windows
 	*		the compilers interpret path correctly.
 	*/
-	void UseRelativePath( bool relative = false, wxString basePath = wxString() );
+	void UseRelativePath(bool relative = false, wxString basePath = wxEmptyString);
 
 	/**
 	* Set the First ID used during Code Generation.

--- a/src/codegen/luacg.h
+++ b/src/codegen/luacg.h
@@ -103,6 +103,13 @@ private:
 	wxString GetCode( PObjectBase obj, wxString name, bool silent = false, wxString strSelf = wxT(""));
 
 	/**
+	* Gets the construction fragment for the specified object.
+	*
+	* This method encapsulates the adjustments that need to be made for array declarations.
+	*/
+	wxString GetConstruction(PObjectBase obj, bool silent, wxString strSelf, ArrayItems& arrays);
+
+	/**
 	* Stores the project's objects classes set, for generating the includes.
 	*/
 	void FindDependencies( PObjectBase obj, std::set< PObjectInfo >& info_set );
@@ -121,7 +128,7 @@ private:
 	/**
 	* Generates classes declarations inside the header file.
 	*/
-	void GenClassDeclaration( PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector &events, const wxString& eventHandlerPostfix );
+	void GenClassDeclaration(PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector& events, const wxString& eventHandlerPostfix, ArrayItems& arrays);
 
 	/**
 	* Generates the event table.
@@ -168,7 +175,7 @@ private:
 	/**
 	* Generates the constructor for a class
 	*/
-	void GenConstructor( PObjectBase class_obj, const EventVector &events, wxString &strClassName );
+	void GenConstructor(PObjectBase class_obj, const EventVector& events, wxString& strClassName, ArrayItems& arrays);
 
 	/**
 	* Generates the destructor for a class
@@ -179,7 +186,7 @@ private:
 	* Makes the objects construction, setting up the objects' and Layout properties.
 	* The algorithm is simmilar to that used in the designer preview generation.
 	*/
-	void GenConstruction( PObjectBase obj, bool is_widget, wxString &strClassName  );
+	void GenConstruction(PObjectBase obj, bool is_widget, wxString& strClassName, ArrayItems& arrays);
 
 	/**
 	* Makes the objects destructions.

--- a/src/codegen/phpcg.cpp
+++ b/src/codegen/phpcg.cpp
@@ -51,8 +51,6 @@ m_basePath( basePath )
 	{
 		m_basePath.clear();
 	}
-
-	//SetupModulePrefixes();
 }
 
 PHPTemplateParser::PHPTemplateParser( const PHPTemplateParser & that, wxString _template )
@@ -62,7 +60,6 @@ m_i18n( that.m_i18n ),
 m_useRelativePath( that.m_useRelativePath ),
 m_basePath( that.m_basePath )
 {
-	//SetupModulePrefixes();
 }
 
 wxString PHPTemplateParser::RootWxParentToCode()
@@ -73,7 +70,7 @@ wxString PHPTemplateParser::RootWxParentToCode()
 PTemplateParser PHPTemplateParser::CreateParser( const TemplateParser* oldparser, wxString _template )
 {
 	const PHPTemplateParser* phpOldParser = dynamic_cast< const PHPTemplateParser* >( oldparser );
-	if ( phpOldParser != NULL )
+	if (phpOldParser)
 	{
 		PTemplateParser newparser( new PHPTemplateParser( *phpOldParser, _template ) );
 		return newparser;
@@ -152,22 +149,6 @@ wxString PHPTemplateParser::ValueToCode( PropertyType type, wxString value )
 	case PT_BITLIST:
 		{
 			result = ( value.empty() ? wxT("0") : value );
-
-			wxString pred, bit;
-			wxStringTokenizer bits( result, wxT("|"), wxTOKEN_STRTOK );
-
-			while( bits.HasMoreTokens() )
-			{
-				bit = bits.GetNextToken();
-				pred = m_predModulePrefix[bit];
-
-				/*if( bit.Contains( wxT("wx") ) )
-				{
-					if( !pred.empty() )	result.Replace( bit, pred + bit.AfterFirst('x') );
-					else
-						result.Replace( bit, wxT("wx") + bit.AfterFirst('x') );
-				}*/
-			}
 			break;
 		}
 	case PT_WXPOINT:
@@ -518,7 +499,7 @@ bool PHPCodeGenerator::GenerateCode( PObjectBase project )
 	}
 	if ( !headerIncludes.empty() )
 	{
-		m_source->WriteLn( wxT("") );
+		m_source->WriteLn(wxEmptyString);
 	}
 
 	// Write internationalization support
@@ -526,7 +507,7 @@ bool PHPCodeGenerator::GenerateCode( PObjectBase project )
 	{
 		//PHP gettext already implements this function
 		//m_source->WriteLn( wxT("function _(){ /*TODO: Implement this function on wxPHP*/ }") );
-		//m_source->WriteLn( wxT("") );
+		//m_source->WriteLn(wxEmptyString);
 	}
 
 	// Generating "defines" for macros
@@ -539,7 +520,9 @@ bool PHPCodeGenerator::GenerateCode( PObjectBase project )
 		 eventHandlerPostfix = wxT("$event->Skip();");
 	}
 	else
-		eventHandlerPostfix = wxT("");
+	{
+		eventHandlerPostfix = wxEmptyString;
+	}
 
 	PProperty disconnectMode = project->GetProperty( wxT("disconnect_mode") );
 	m_disconnecMode = disconnectMode->GetValueAsString();
@@ -555,7 +538,7 @@ bool PHPCodeGenerator::GenerateCode( PObjectBase project )
 		EventVector events;
 		FindEventHandlers( child, events );
 		//GenClassDeclaration( child, useEnum, classDecoration, events, eventHandlerPrefix, eventHandlerPostfix );
-		GenClassDeclaration(child, false, wxT(""), events, eventHandlerPostfix, arrays);
+		GenClassDeclaration(child, false, wxEmptyString, events, eventHandlerPostfix, arrays);
 	}
 
 	code = GetCode( project, wxT("php_epilogue") );
@@ -638,7 +621,7 @@ bool PHPCodeGenerator::GenEventEntry( PObjectBase obj, PObjectInfo obj_info, con
 	PCodeInfo code_info = obj_info->GetCodeInfo( wxT("PHP") );
 	if ( code_info )
 	{
-		_template = code_info->GetTemplate( wxString::Format( wxT("evt_%s%s"), disconnect ? wxT("dis") : wxT(""), templateName.c_str() ) );
+		_template = code_info->GetTemplate(wxString::Format(wxT("evt_%s%s"), disconnect ? wxT("dis") : wxEmptyString, templateName.c_str()));
 		if ( disconnect && _template.empty() )
 		{
 			_template = code_info->GetTemplate( wxT("evt_") + templateName );
@@ -757,7 +740,7 @@ wxString PHPCodeGenerator::GetCode(PObjectBase obj, wxString name, bool silent)
 				name.c_str(), obj->GetClassName().c_str() ) );
 			wxLogError(msg);
 		}
-		return wxT("");
+		return wxEmptyString;
 	}
 
 	_template = code_info->GetTemplate(name);
@@ -855,7 +838,7 @@ void PHPCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool /*use_enu
 	GenConstructor(class_obj, events, arrays);
 	GenDestructor( class_obj, events );
 
-	m_source->WriteLn( wxT("") );
+	m_source->WriteLn(wxEmptyString);
 
 	// event handlers
 	GenVirtualEventHandlers(events, eventHandlerPostfix);
@@ -863,7 +846,7 @@ void PHPCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool /*use_enu
 
 	m_source->Unindent();
 	m_source->WriteLn( wxT("}") );
-	m_source->WriteLn( wxT("") );
+	m_source->WriteLn(wxEmptyString);
 }
 
 void PHPCodeGenerator::GenSubclassSets( PObjectBase obj, std::set< wxString >* subclasses, std::vector< wxString >* headerIncludes )
@@ -1071,7 +1054,7 @@ void PHPCodeGenerator::GenConstructor(PObjectBase class_obj, const EventVector& 
 
 	m_source->Unindent();
 	m_source->WriteLn( wxT("}") );
-	m_source->WriteLn( wxT("") );
+	m_source->WriteLn(wxEmptyString);
 
 	if ( class_obj->GetObjectTypeName() == wxT("wizard") && class_obj->GetChildCount() > 0 )
 	{
@@ -1414,7 +1397,10 @@ void PHPCodeGenerator::GenDefines( PObjectBase project)
 		m_source->WriteLn( wxString::Format( wxT("const %s = %i;"), it->c_str(), id ) );
 		id++;
 	}
-	if( !macros.empty() ) m_source->WriteLn( wxT("") );
+	if (!macros.empty())
+	{
+		m_source->WriteLn(wxEmptyString);
+	}
 }
 
 void PHPCodeGenerator::GenSettings(PObjectInfo info, PObjectBase obj)
@@ -1488,13 +1474,18 @@ void PHPCodeGenerator::GetAddToolbarCode( PObjectInfo info, PObjectBase obj, wxA
 
 void PHPCodeGenerator::UseRelativePath(bool relative, wxString basePath)
 {
-	bool result;
 	m_useRelativePath = relative;
 
 	if (m_useRelativePath)
 	{
-		result = wxFileName::DirExists( basePath );
-		m_basePath = ( result ? basePath : wxT("") );
+		if (wxFileName::DirExists(basePath))
+		{
+			m_basePath = basePath;
+		}
+		else
+		{
+			m_basePath = wxEmptyString;
+		}
 	}
 }
 /*

--- a/src/codegen/phpcg.h
+++ b/src/codegen/phpcg.h
@@ -47,6 +47,7 @@ The value of all properties that are file or a directory paths must be absolute,
 #include "codegen.h"
 
 #include <set>
+#include <vector>
 
 /**
 * Parse the PHP templates.
@@ -57,10 +58,6 @@ private:
 	bool m_i18n;
 	bool m_useRelativePath;
 	wxString m_basePath;
-
-	std::map<wxString, wxString> m_predModulePrefix;
-
-	void SetupModulePrefixes();
 
 public:
 	PHPTemplateParser( PObjectBase obj, wxString _template, bool useI18N, bool useRelativePath, wxString basePath );
@@ -225,7 +222,7 @@ public:
 	* @note path is generated with the separators, '/', since on Windows
 	*		the compilers interpret path correctly.
 	*/
-	void UseRelativePath( bool relative = false, wxString basePath = wxString() );
+	void UseRelativePath(bool relative = false, wxString basePath = wxEmptyString);
 
 	/**
 	* Set the First ID used during Code Generation.

--- a/src/codegen/phpcg.h
+++ b/src/codegen/phpcg.h
@@ -100,6 +100,13 @@ private:
 	wxString GetCode( PObjectBase obj, wxString name, bool silent = false);
 
 	/**
+	* Gets the construction fragment for the specified object.
+	*
+	* This method encapsulates the adjustments that need to be made for array declarations.
+	*/
+	wxString GetConstruction(PObjectBase obj, ArrayItems& arrays);
+
+	/**
 	* Stores the project's objects classes set, for generating the includes.
 	*/
 	void FindDependencies( PObjectBase obj, std::set< PObjectInfo >& info_set );
@@ -118,7 +125,7 @@ private:
 	/**
 	* Generates classes declarations inside the header file.
 	*/
-	void GenClassDeclaration( PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector &events, const wxString& eventHandlerPostfix );
+	void GenClassDeclaration(PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector& events, const wxString& eventHandlerPostfix, ArrayItems& arrays);
 
 	/**
 	* Generates the event table.
@@ -160,7 +167,7 @@ private:
 	/**
 	* Generates the constructor for a class
 	*/
-	void GenConstructor( PObjectBase class_obj, const EventVector &events );
+	void GenConstructor(PObjectBase class_obj, const EventVector& events, ArrayItems& arrays);
 
 	/**
 	* Generates the destructor for a class
@@ -171,7 +178,7 @@ private:
 	* Makes the objects construction, setting up the objects' and Layout properties.
 	* The algorithm is simmilar to that used in the designer preview generation.
 	*/
-	void GenConstruction( PObjectBase obj, bool is_widget );
+	void GenConstruction(PObjectBase obj, bool is_widget, ArrayItems& arrays);
 
 	/**
 	* Makes the objects destructions.

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -73,7 +73,7 @@ wxString PythonTemplateParser::RootWxParentToCode()
 PTemplateParser PythonTemplateParser::CreateParser( const TemplateParser* oldparser, wxString _template )
 {
 	const PythonTemplateParser* pythonOldParser = dynamic_cast< const PythonTemplateParser* >( oldparser );
-	if ( pythonOldParser != NULL )
+	if (pythonOldParser)
 	{
 		PTemplateParser newparser( new PythonTemplateParser( *pythonOldParser, _template ) );
 		return newparser;
@@ -532,7 +532,7 @@ bool PythonCodeGenerator::GenerateCode( PObjectBase project )
 	}
 	if ( !headerIncludes.empty() )
 	{
-		m_source->WriteLn( wxT("") );
+		m_source->WriteLn(wxEmptyString);
 	}
 
 	// Write internationalization support
@@ -540,7 +540,7 @@ bool PythonCodeGenerator::GenerateCode( PObjectBase project )
 	{
 		m_source->WriteLn( wxT("import gettext") );
 		m_source->WriteLn( wxT("_ = gettext.gettext") );
-		m_source->WriteLn( wxT("") );
+		m_source->WriteLn(wxEmptyString);
 	}
 
 	// Generating "defines" for macros
@@ -569,7 +569,7 @@ bool PythonCodeGenerator::GenerateCode( PObjectBase project )
 		EventVector events;
 		FindEventHandlers( child, events );
 		//GenClassDeclaration( child, useEnum, classDecoration, events, eventHandlerPrefix, eventHandlerPostfix );
-		GenClassDeclaration(child, false, wxT(""), events, eventHandlerPostfix, arrays);
+		GenClassDeclaration(child, false, wxEmptyString, events, eventHandlerPostfix, arrays);
 	}
 
 	code = GetCode( project, wxT("python_epilogue") );
@@ -652,7 +652,7 @@ bool PythonCodeGenerator::GenEventEntry( PObjectBase obj, PObjectInfo obj_info, 
 	PCodeInfo code_info = obj_info->GetCodeInfo( wxT("Python") );
 	if ( code_info )
 	{
-		_template = code_info->GetTemplate( wxString::Format( wxT("evt_%s%s"), disconnect ? wxT("dis") : wxT(""), templateName.c_str() ) );
+		_template = code_info->GetTemplate(wxString::Format(wxT("evt_%s%s"), disconnect ? wxT("dis") : wxEmptyString, templateName.c_str()));
 		if ( disconnect && _template.empty() )
 		{
 			_template = code_info->GetTemplate( wxT("evt_") + templateName );
@@ -770,7 +770,7 @@ wxString PythonCodeGenerator::GetCode(PObjectBase obj, wxString name, bool silen
 				name.c_str(), obj->GetClassName().c_str() ) );
 			wxLogError(msg);
 		}
-		return wxT("");
+		return wxEmptyString;
 	}
 
 	_template = code_info->GetTemplate(name);
@@ -896,14 +896,14 @@ void PythonCodeGenerator::GenClassDeclaration(PObjectBase class_obj, bool /*use_
 	GenConstructor(class_obj, events, arrays);
 	GenDestructor( class_obj, events );
 
-	m_source->WriteLn( wxT("") );
+	m_source->WriteLn(wxEmptyString);
 
 	// event handlers
 	GenVirtualEventHandlers(events, eventHandlerPostfix);
 	GetGenEventHandlers( class_obj );
 
 	m_source->Unindent();
-	m_source->WriteLn( wxT("") );
+	m_source->WriteLn(wxEmptyString);
 }
 
 void PythonCodeGenerator::GenSubclassSets( PObjectBase obj, std::set< wxString >* subclasses, std::vector< wxString >* headerIncludes )
@@ -1454,7 +1454,10 @@ void PythonCodeGenerator::GenDefines( PObjectBase project)
 		m_source->WriteLn( wxString::Format( wxT("%s = %i"), it->c_str(), id ) );
 		id++;
 	}
-	if( !macros.empty() ) m_source->WriteLn( wxT("") );
+	if (!macros.empty())
+	{
+		m_source->WriteLn(wxEmptyString);
+	}
 }
 
 void PythonCodeGenerator::GenSettings(PObjectInfo info, PObjectBase obj)
@@ -1528,13 +1531,18 @@ void PythonCodeGenerator::GetAddToolbarCode( PObjectInfo info, PObjectBase obj, 
 
 void PythonCodeGenerator::UseRelativePath(bool relative, wxString basePath)
 {
-	bool result;
 	m_useRelativePath = relative;
 
 	if (m_useRelativePath)
 	{
-		result = wxFileName::DirExists( basePath );
-		m_basePath = ( result ? basePath : wxT("") );
+		if (wxFileName::DirExists(basePath))
+		{
+			m_basePath = basePath;
+		}
+		else
+		{
+			m_basePath = wxEmptyString;
+		}
 	}
 }
 /*

--- a/src/codegen/pythoncg.h
+++ b/src/codegen/pythoncg.h
@@ -97,6 +97,13 @@ private:
 	wxString GetCode( PObjectBase obj, wxString name, bool silent = false);
 
 	/**
+	* Gets the construction fragment for the specified object.
+	*
+	* This method encapsulates the adjustments that need to be made for array declarations.
+	*/
+	wxString GetConstruction(PObjectBase obj, bool silent, ArrayItems& arrays);
+
+	/**
 	* Stores the project's objects classes set, for generating the includes.
 	*/
 	void FindDependencies( PObjectBase obj, std::set< PObjectInfo >& info_set );
@@ -115,7 +122,7 @@ private:
 	/**
 	* Generates classes declarations inside the header file.
 	*/
-	void GenClassDeclaration( PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector &events, const wxString& eventHandlerPostfix );
+	void GenClassDeclaration(PObjectBase class_obj, bool use_enum, const wxString& classDecoration, const EventVector& events, const wxString& eventHandlerPostfix, ArrayItems& arrays);
 
 	/**
 	* Generates the event table.
@@ -157,7 +164,7 @@ private:
 	/**
 	* Generates the constructor for a class
 	*/
-	void GenConstructor( PObjectBase class_obj, const EventVector &events );
+	void GenConstructor(PObjectBase class_obj, const EventVector& events, ArrayItems& arrays);
 
 	/**
 	* Generates the destructor for a class
@@ -168,7 +175,7 @@ private:
 	* Makes the objects construction, setting up the objects' and Layout properties.
 	* The algorithm is simmilar to that used in the designer preview generation.
 	*/
-	void GenConstruction( PObjectBase obj, bool is_widget );
+	void GenConstruction(PObjectBase obj, bool is_widget, ArrayItems& arrays);
 
 	/**
 	* Makes the objects destructions.

--- a/src/codegen/pythoncg.h
+++ b/src/codegen/pythoncg.h
@@ -43,7 +43,9 @@ The value of all properties that are file or a directory paths must be absolute,
 
 #include "codegen.h"
 
+#include <map>
 #include <set>
+#include <vector>
 
 /**
 * Parse the Python templates.
@@ -222,7 +224,7 @@ public:
 	* @note path is generated with the separators, '/', since on Windows
 	*		the compilers interpret path correctly.
 	*/
-	void UseRelativePath( bool relative = false, wxString basePath = wxString() );
+	void UseRelativePath(bool relative = false, wxString basePath = wxEmptyString);
 
 	/**
 	* Set the First ID used during Code Generation.


### PR DESCRIPTION
This allows to use names of the form myWidget[0], myWidget[1], ... for objects, multiple dimensions are also allowed. Additionally for C++ an anonymous enum with symbols of the form MYWIDGET_SIZE for single dimensional arrays and MYWIDGET_0_SIZE, MYWIDGET_1_SIZE, ... for multi dimensional arrays are created which store the number of elements in the corresponding dimension.

This change is local to the C++ code generator with one catch that i will explain below.

This is a minimal-change-approach implementation that bases on the fact that declaring a static array and accessing its members is syntactically identical of using a regular member, only special care has to be taken during declaration of the array to declare it only once with the correct dimensions.

The implementation works like this:
- In a preprocessing step for each top-level object parse its object tree and extract the name of every found array and record the highest used index
- The two locations that declare an object compare the name of the current object against the list of array names
- If the name does not match an array continue as usual, otherwise
- If the array has already been declared skip the object, otherwise
- Create the enum values with the count of the elements in the dimensions
- Temporary rename the object to contain the count of elements instead the current index
- Call the declaration template
- Restore the name of the object, mark the array as declared and continue as usual

Now the catch, certain code templates, e.g. for a wxChoice, contain fragments like this:
`wxArrayString $name #append data;`
This will result in an invalid identifier if `$name` contains array brackets `[]`. The same approach like before, renaming the object to something else, doesn't work here because there are other locations in the template that actually need the name with the array index. To solve this, the `#append` function searches for the beginning of its preceeding token and replaces `[]` with `_`.

The template processor however is generic code, it is used by all targets so this will affect the other generators as well. I checked all templates and this change *should* not break anything, but i am not totally sure because i don't know enough of the other languages. And this is also the reason why this is only implemented in C++, i am unable to implement this for the other languages and don't know if this is even possible or necessary at all, maybe some smart tricks work there out-of-the-box.

This feature however is very important for me and one of the reasons why i have a not-so-private-anymore fork of wxFormBuilder, so if it won't make it into the official project again (it got rejected in the SourceForge days), maybe others can help to implement this for the other target languages to get a better chance to get it accepted.