### PR TITLE
Adds the feature to load bitmap resources from XRC

### DIFF
--- a/sdk/plugin_interface/xrcconv.cpp
+++ b/sdk/plugin_interface/xrcconv.cpp
@@ -220,7 +220,7 @@ void ObjectToXrcFilter::AddProperty( const wxString &objPropName,
 					break;
 				}
 
-				if ( bitmapProp.StartsWith( _("Load From File") ) || bitmapProp.StartsWith( _("Load From Embedded File") ) )
+				if (bitmapProp.StartsWith(_("Load From File")) || bitmapProp.StartsWith(_("Load From Embedded File")) || bitmapProp.StartsWith(_("Load From XRC")))
 				{
 					LinkText( filename.Trim().Trim(false), &propElement );
 				}

--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -306,6 +306,10 @@ wxString CppTemplateParser::ValueToCode( PropertyType type, wxString value )
 					result.Printf( wxT( "wxIcon( wxT(\"%s\"), wxBITMAP_TYPE_ICO_RESOURCE, %i, %i )" ), path.c_str(), icoSize.GetWidth(), icoSize.GetHeight() );
 				}
 			}
+			else if (source == _("Load From XRC"))
+			{
+				result << wxT("wxXmlResource::Get()->LoadBitmap( wxT(\"") << path << wxT("\") )");
+			}
 			else if ( source == _("Load From Art Provider") )
 			{
 				wxString rid = path.BeforeFirst( wxT(':') );
@@ -2020,6 +2024,12 @@ void CppCodeGenerator::FindEmbeddedBitmapProperties( PObjectBase obj, std::set<w
 				inc << wxT( "#include \"" ) << includePath << wxT( "\"" );
 				embedset.insert( inc );
 			}
+			// NOTE: This is currently not necessary because the default code already contains this header.
+			//       Because the unique include filtering is not global this cannot be enabled without creating a duplicate entry.
+			//else if (source == _("Load From XRC"))
+			//{
+			//	embedset.insert(wxT("#include <wx/xrc/xmlres.h>"));
+			//}
 		}
 	}
 

--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -323,6 +323,11 @@ wxString LuaTemplateParser::ValueToCode( PropertyType type, wxString value )
 					result.Printf( wxT("wx.Icon( u\"%s\", wx.wxBITMAP_TYPE_ICO_RESOURCE, %i, %i )"), path.c_str(), icoSize.GetWidth(), icoSize.GetHeight() );
 				}*/
 			}
+			else if (source == _("Load From XRC"))
+			{
+				// This requires that the global wxXmlResource object is set
+				result << wxT("wx.wxXmlResource.Get():LoadBitmap( \"") << path << wxT("\" )");
+			}
 			else if ( source == _("Load From Art Provider") )
 			{
 				wxString rid = path.BeforeFirst( wxT(':') );

--- a/src/codegen/phpcg.cpp
+++ b/src/codegen/phpcg.cpp
@@ -302,6 +302,11 @@ wxString PHPTemplateParser::ValueToCode( PropertyType type, wxString value )
 					result.Printf( wxT("new wxIcon( \"%s\", wxBITMAP_TYPE_ICO_RESOURCE, %i, %i )"), path.c_str(), icoSize.GetWidth(), icoSize.GetHeight() );
 				}
 			}
+			else if (source == _("Load From XRC"))
+			{
+				// This requires that the global wxXmlResource object is set
+				result << wxT("wxXmlResource::Get()->LoadBitmap( \"") << path << wxT("\" )");
+			}
 			else if ( source == _("Load From Art Provider") )
 			{
 				wxString rid = path.BeforeFirst( wxT(':') );

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -309,6 +309,11 @@ wxString PythonTemplateParser::ValueToCode( PropertyType type, wxString value )
 					result.Printf( wxT("wx.Icon( u\"%s\", wx.BITMAP_TYPE_ICO_RESOURCE, %i, %i )"), path.c_str(), icoSize.GetWidth(), icoSize.GetHeight() );
 				}
 			}
+			else if (source == _("Load From XRC"))
+			{
+				// NOTE: The module wx.xrc is part of the default code template
+				result << wxT("wx.xrc.XmlResource.Get().LoadBitmap( u\"") << path << wxT("\" )");
+			}
 			else if ( source == _("Load From Art Provider") )
 			{
 				wxString rid = path.BeforeFirst( wxT(':') );

--- a/src/rad/inspector/wxfbadvprops.cpp
+++ b/src/rad/inspector/wxfbadvprops.cpp
@@ -499,99 +499,106 @@ wxFBBitmapProperty::~wxFBBitmapProperty()
 }
 
 wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int childIndex,
-                                           wxVariant& childValue) const {
-	wxFBBitmapProperty* bp = (wxFBBitmapProperty*)this;
+                                           wxVariant& childValue) const
+{
+	auto* bp = const_cast<wxFBBitmapProperty*>(this);
 
-    wxString val = thisValue.GetString();
+	const auto val = thisValue.GetString();
 	wxArrayString childVals;
-	GetChildValues( val, childVals );
-	wxString newVal = val;
+	GetChildValues(val, childVals);
+	auto newVal = val;
 
-    // Find the appropriate new state
-    switch ( childIndex )
-    {
-        // source
-        case 0:
-        {
-			unsigned int count = GetChildCount();
+	// Find the appropriate new state
+	switch (childIndex)
+	{
+		// source
+		case 0:
+		{
+			const auto count = GetChildCount();
 
-            // childValue.GetInteger() returns the chosen item index
-            switch ( childValue.GetInteger() )
-            {
-                // 'Load From File' and 'Load From Embedded File'
-                case 0:
-                case 1:
-                {
-					if( prevSrc != 0 && prevSrc!= 1 )
+			// childValue.GetInteger() returns the chosen item index
+			switch (childValue.GetInteger())
+			{
+				// 'Load From File' and 'Load From Embedded File'
+				case 0:
+				case 1:
+				{
+					if (prevSrc != 0 && prevSrc!= 1)
 					{
-					    for ( unsigned int i = 1; i<count ;i++ )
+						for (unsigned int i = 1; i < count ; ++i)
 						{
-							wxPGProperty *p = Item(i) ;
-							if ( p )
+							if (auto* p = Item(i))
 							{
-								wxLogDebug( wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str() );
-								GetGrid()->DeleteProperty( p );
+								wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str());
+								GetGrid()->DeleteProperty(p);
 							}
 						}
-						bp->AppendChild( bp->CreatePropertyFilePath() );
+						bp->AppendChild(bp->CreatePropertyFilePath());
 					}
 
-					if( childVals.GetCount() == 2 )
+					if (childVals.GetCount() == 2)
+					{
 						newVal = childVals.Item(0) + wxT("; ") + childVals.Item(1);
-					else if( childVals.GetCount() > 1 )
-						newVal = childVals.Item(0) + wxT("; ");
-
-                    break;
-                }
-                // 'Load From Resource'
-                case 2:
-                {
-					if( prevSrc != 2 )
+					}
+					else if (childVals.GetCount() > 0)
 					{
-						for ( unsigned int i = 1; i<count ;i++ )
+						newVal = childVals.Item(0) + wxT("; ");
+					}
+					break;
+				}
+				// 'Load From Resource'
+				case 2:
+				{
+					if (prevSrc != 2)
+					{
+						for (unsigned int i = 1; i < count ; ++i)
 						{
-							wxPGProperty *p = Item(i) ;
-							if ( p )
+							if (auto* p = Item(i))
 							{
-								wxLogDebug( wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str() );
-								GetGrid()->DeleteProperty( p );
+								wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str());
+								GetGrid()->DeleteProperty(p);
 							}
 						}
-						bp->AppendChild( bp->CreatePropertyResourceName() );
+						bp->AppendChild(bp->CreatePropertyResourceName());
 					}
 
-					if( childVals.GetCount() == 2)
+					if (childVals.GetCount() == 2)
+					{
 						newVal = childVals.Item(0) + wxT("; ") + childVals.Item(1);
-					else if( childVals.GetCount() > 1 )
-						newVal = childVals.Item(0) + wxT("; ");
-
-                    break;
-                }
-                // 'Load From Icon Resource'
-                case 3:
-                {
-					if( prevSrc != 3 )
+					}
+					else if (childVals.GetCount() > 0)
 					{
-						for ( unsigned int i = 1; i<count ;i++ )
+						newVal = childVals.Item(0) + wxT("; ");
+					}
+					break;
+				}
+				// 'Load From Icon Resource'
+				case 3:
+				{
+					if (prevSrc != 3)
+					{
+						for (unsigned int i = 1; i < count ; ++i)
 						{
-							wxPGProperty *p = Item(i) ;
-							if ( p )
+							if (auto* p = Item(i))
 							{
-								wxLogDebug( wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str() );
-								GetGrid()->DeleteProperty( p );
+								wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str());
+								GetGrid()->DeleteProperty(p);
 							}
 						}
-						bp->AppendChild( bp->CreatePropertyResourceName() );
-						bp->AppendChild( bp->CreatePropertyIconSize() );
+						bp->AppendChild(bp->CreatePropertyResourceName());
+						bp->AppendChild(bp->CreatePropertyIconSize());
 					}
 
-					if( childVals.GetCount() == 3)
+					if (childVals.GetCount() == 3)
+					{
 						newVal = childVals.Item(0) + wxT("; ") + childVals.Item(1) + wxT("; [") + childVals.Item(2) + wxT("]");
-					else if( childVals.GetCount() > 1 )
+					}
+					else if (childVals.GetCount() > 0)
+					{
 						newVal = childVals.Item(0) + wxT("; ; []");
-
-                    break;
-                }
+					}
+					break;
+				}
 				// 'Load From XRC'
 				case 4:
 				{
@@ -620,31 +627,34 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
 				}
 				// 'Load From Art Provider'
 				case 5:
-                {
+				{
 					if (prevSrc != 5)
 					{
-						for ( unsigned int i = 1; i<count ;i++ )
+						for (unsigned int i = 1; i < count ; ++i)
 						{
-							wxPGProperty *p = Item(i) ;
-							if ( p )
+							if (auto* p = Item(i))
 							{
-								wxLogDebug( wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str() );
-								GetGrid()->DeleteProperty( p );
+								wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel().c_str());
+								GetGrid()->DeleteProperty(p);
 							}
 						}
-						bp->AppendChild( bp->CreatePropertyArtId() );
-						bp->AppendChild( bp->CreatePropertyArtClient() );
+						bp->AppendChild(bp->CreatePropertyArtId());
+						bp->AppendChild(bp->CreatePropertyArtClient());
 					}
 
-					if( childVals.GetCount() == 3)
+					if (childVals.GetCount() == 3)
+					{
 						newVal = childVals.Item(0) + wxT("; ") + childVals.Item(1) + wxT("; ") + childVals.Item(2);
-					else if( childVals.GetCount() > 1 )
+					}
+					else if (childVals.GetCount() > 0)
+					{
 						newVal = childVals.Item(0) + wxT("; ; ");
-                    break;
-                }
-            }
-            break;
-        }
+					}
+					break;
+				}
+			}
+			break;
+		}
 
         // file_path || id || resource_name || xrc_name
         case 1:

--- a/src/rad/inspector/wxfbadvprops.h
+++ b/src/rad/inspector/wxfbadvprops.h
@@ -96,6 +96,7 @@ public:
     wxPGProperty *CreatePropertyFilePath() ;
     wxPGProperty *CreatePropertyResourceName();
     wxPGProperty *CreatePropertyIconSize();
+	wxPGProperty *CreatePropertyXrcName();
     wxPGProperty *CreatePropertyArtId();
     wxPGProperty *CreatePropertyArtClient();
 


### PR DESCRIPTION
A new option gets added to the wxFBBitmapProperty to load the bitmap from the XRC system. This allows using [Binary Resource Files](http://docs.wxwidgets.org/trunk/overview_xrc.html). It is up to the application code to initialize the resources. Currently this is only possible for the C++ target because of lack of knowledge if and how the other targets support this.

All other languages return a wxNullBitmap if this method is selected, this is what they already do if one of the other unsupported methods for the language is selected.

This is the second feature of my not-so-private-anymore fork of wxFormBuilder that got rejected in the past because it was only implemented for C++, maybe someone else can verify that the other languages don't support this or can implement this for them if possible.