### PR TITLE
Fix python code generation for wx.CollapsiblePane.

### DIFF
--- a/output/plugins/containers/xml/containers.pythoncode
+++ b/output/plugins/containers/xml/containers.pythoncode
@@ -32,7 +32,7 @@ Python code generation written by
 
 	<templates class="wxCollapsiblePane">
 		<template name="construction">self.$name = #class( #wxparent $name, $id, $label, $pos, $size, $style #ifnotnull $window_style @{|$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )</template>
-		<template name="settings">#ifnotnull $collapsed @{ $name.Collapse( $collapsed ) #nl @}</template>
+		<template name="settings">#ifnotnull $collapsed @{ self.$name.Collapse( $collapsed ) #nl @}</template>
 		<template name="evt_connect_OnCollapsiblePaneChanged">self.$name.Bind( wx.EVT_COLLAPSIBLEPANE_CHANGED, #handler )</template>
 	</templates>
 


### PR DESCRIPTION
The template code to set the "collapsed" attribute tried to call the
Collapse() method without prepending the object (self).