### PR TITLE
Add define for wxFALLTHROUGH for wxWidgets earlier than v3.0.3.

### DIFF
--- a/src/utils/typeconv.cpp
+++ b/src/utils/typeconv.cpp
@@ -32,6 +32,10 @@
 #include <wx/artprov.h>
 #include <wx/filesys.h>
 
+#ifndef wxFALLTHROUGH
+    #define wxFALLTHROUGH ((void)0)
+#endif
+
 ////////////////////////////////////
 
 // Assuming that the locale is constant throughout one execution,


### PR DESCRIPTION
Versions of wxWidgets earlier than v3.0.3 lack a define for wxFALLTHROUGH, which is why #429 happens.  Looking at the source code of wxWidgets, I see this:

```
/* wxFALLTHROUGH is used to notate explicit fallthroughs in switch statements */
#ifdef __cplusplus
#if __cplusplus >= 201103L && defined(__has_warning)
    #if WX_HAS_CLANG_FEATURE(cxx_attributes)
        #define wxFALLTHROUGH [[clang::fallthrough]]
    #endif
#endif
#endif /* __cplusplus */

#ifndef wxFALLTHROUGH
    #define wxFALLTHROUGH ((void)0)
#endif
```

I just opted to add the last ifdef-define-endif, which returns the code to how it was before a3f139f5e20949e9a5a23cc954234a1bacdd10f2.