### PR TITLE
Accept additional wxPanel constructor arguments

### DIFF
--- a/output/plugins/forms/xml/forms.cppcode
+++ b/output/plugins/forms/xml/forms.cppcode
@@ -231,18 +231,18 @@ Written by
 			@{ public wxPanel @}
 		</template>
 		<template name="cons_decl">
-			$name( wxWindow* parent, wxWindowID id = $id, const wxPoint&amp; pos = $pos, const wxSize&amp; size = $size, long style = $window_style #ifnotnull $window_name @{, const wxString&amp; name = $window_name @} );
+			$name( wxWindow* parent, wxWindowID id = $id, const wxPoint&amp; pos = $pos, const wxSize&amp; size = $size, long style = $window_style, const wxString&amp; name = $window_name );
 			#ifequal $aui_managed "1"
 			@{ wxAuiManager m_mgr; #nl @}
 		</template>
 		<template name="cons_def">
-			$name::$name( wxWindow* parent, wxWindowID id, const wxPoint&amp; pos, const wxSize&amp; size, long style#ifnotnull $window_name @{, const wxString&amp; name@} ) :
+			$name::$name( wxWindow* parent, wxWindowID id, const wxPoint&amp; pos, const wxSize&amp; size, long style, const wxString&amp; name ) :
 
 			#ifnotnull $subclass/name
 			@{ $subclass/name @}
 
 			#ifnull $subclass/name
-			@{ wxPanel@}( parent, id, pos, size, style#ifnotnull $window_name @{, name@} )
+			@{ wxPanel@}( parent, id, pos, size, style, name )
 		</template>
 			<template name="destruction">
 			#ifequal $aui_managed "1"

--- a/output/plugins/forms/xml/forms.phpcode
+++ b/output/plugins/forms/xml/forms.phpcode
@@ -242,10 +242,10 @@ PHP code generation writen by
 			@{ wxPanel @}
 		</template>
 		<template name="cons_def">
-			function __construct( @$parent=null ){
+			function __construct( @$parent=null, @$id=$id, @$pos=$pos, @$size=$size, @$style=$window_style, @$name=$window_name ){
 		</template>
 		<template name="cons_call">
-			parent::__construct( @$parent, $id, $pos, $size, $window_style #ifnotnull $window_name @{, $window_name @} );
+			parent::__construct( @$parent, @$id, @$pos, @$size, @$style, @$name );
 		</template>
 		<template name="destruction">
 			#ifequal $aui_managed "1"

--- a/output/plugins/forms/xml/forms.pythoncode
+++ b/output/plugins/forms/xml/forms.pythoncode
@@ -230,7 +230,7 @@ Python code generation writen by
 			@{ wx.Panel @}
 		</template>
 		<template name="cons_def">
-			def __init__( self, parent ):
+			def __init__( self, parent, id = $id, pos = $pos, size = $size, style = $window_style, name = $window_name ):
 		</template>
 		<template name="cons_call">
 			#ifnotnull $subclass/name
@@ -238,7 +238,7 @@ Python code generation writen by
 
 			#ifnull $subclass/name
 			@{ wx.Panel.__init__@}
-			( self, parent, id = $id, pos = $pos, size = $size, style = $window_style #ifnotnull $window_name @{, name = $window_name @} )
+			( self, parent, id = id, pos = pos, size = size, style = style, name = name )
 		</template>
 		<template name="destruction">
 			#ifequal $aui_managed "1"


### PR DESCRIPTION
This PR brings the Python and PHP code generation templates up to par with the C++ template.

Add arguments `id`, `pos`, `size`, `style` and `name` to the generated constructors for wxPanel forms. Provide the attributes from the project as default values to these constructor arguments.  Pass the arguments down to the respective parent constructor.

* For Python, this fixes #261.
* The PHP and C++ changes have not been tested at runtime, only checked that the generated source files look correct.
* For C++, only the `#ifnotnull $window_name` check is removed, since the default value is correctly declared as `wxEmptyString` in case the attribute was empty.  This is consistent with the other two language implementations.
* I don't know Lua at all and as far as I could tell, the generated code is not really object oriented like the other languages.  If needed, someone with more Lua-fu might have to look into this.

This allows more flexible use of the generated Panel form classes, especially when reusing the panel within other project elements via their subclass attribute.  That previously failed because the constructors did not accept the extra arguments provided from the project.