### PR TITLE
Fix reading and writing of the subclass element and all other PT_PARENT

### DIFF
--- a/output/xml/default.xml
+++ b/output/xml/default.xml
@@ -134,6 +134,10 @@
     <property name="subclass" type="parent" help="For easy use of custom widgets which are simple variations from standard ones, without requiring a new plugin for wxFB or a full xrc handler for wxWidgets. For C++, this replaces the name of the class. For XRC, this sets the subclass value on the object tag.">
 		<child name="name" help="The name of the subclass."/>
 		<child name="header" help="For C++ Only. The header to be included for the subclass."/>
+      <!-- Note: Because the element type parent is stored in the format of a composed wxPGProperty the value has to be specified in this format:
+                 true == forward_declare
+                 false == Not forward_declare
+      -->
 		<child name="forward_declare" type="bool" help="For C++ Only. Forward declare the subclass, otherwise include the header.">forward_declare</child>
 	</property>
 	<category name="wxKeyEvent" type="interface">

--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -1285,7 +1285,8 @@ void CppCodeGenerator::GenSubclassSets( PObjectBase obj, std::set< wxString >* s
 		std::map< wxString, wxString >::iterator forward_declare_it = children.find( wxT( "forward_declare" ) );
 		if ( children.end() != forward_declare_it )
 		{
-			forward_declare = forward_declare_it->second == wxT( "forward_declare" );
+			// The value needs to be tested like ObjectInspector does
+			forward_declare = (forward_declare_it->second == forward_declare_it->first);
 		}
 
 		//get namespaces

--- a/src/model/database.cpp
+++ b/src/model/database.cpp
@@ -1214,22 +1214,25 @@ void ObjectDatabase::ParseProperties( ticpp::Element* elem_obj, PObjectInfo obj_
 				child.m_type = ParsePropertyType( _WXSTR( child_type ) );
 
 				// Get default value
+				// Empty tags don't contain any child so this will throw in that case
+				std::string child_value;
 				try
 				{
 					ticpp::Node* lastChild = elem_child->LastChild();
 					ticpp::Text* text = lastChild->ToText();
-					child.m_defaultValue = _WXSTR( text->Value() );
-
-					// build parent default value
-					if ( children.size() > 0 )
-					{
-						def_value += "; ";
-					}
-					def_value += text->Value();
+					child_value = text->Value();
 				}
 				catch( ticpp::Exception& ){}
+				child.m_defaultValue = _WXSTR(child_value);
 
-				children.push_back( child );
+				// build parent default value
+				if (children.size() > 0)
+				{
+					def_value += "; ";
+				}
+				def_value += child_value;
+				
+				children.push_back(child);
 
 				elem_child = elem_child->NextSiblingElement( "child", false );
 			}

--- a/src/rad/inspector/objinspect.cpp
+++ b/src/rad/inspector/objinspect.cpp
@@ -487,7 +487,10 @@ void ObjectInspector::AddItems( const wxString& name, PObjectBase obj,
 						wxPGProperty* child = nullptr;
 						if( PT_BOOL == it->m_type )
 						{
-							child = new wxBoolProperty( it->m_name, wxPG_LABEL, value.IsEmpty() || (value == it->m_name) );
+							// Because the format of a composed wxPGProperty value is stored this needs to be converted
+							// true == "<property name>"
+							// false == "Not <property name>"
+							child = new wxBoolProperty(it->m_name, wxPG_LABEL, value == it->m_name);
 						}
 						else if( PT_WXSTRING == it->m_type )
 						{
@@ -736,8 +739,11 @@ void ObjectInspector::OnPropertyGridChanged( wxPropertyGridEvent& event )
 			}
 			case PT_PARENT:
 			{
-				wxVariant value = propPtr->GetValue();
-				ModifyProperty( prop, propPtr->ValueToString( value, wxPG_FULL_VALUE ));
+				// GenerateComposedValue() is the only method that does actually return a value,
+				// although the documentation claims the other methods just call this one,
+				// they return an empty value
+				const auto value = propPtr->GenerateComposedValue();
+				ModifyProperty(prop, value);
 				break;
 			}
 			case PT_WXSTRING:


### PR DESCRIPTION
The method used to extract the value of a composed wxPGProperty always returns an empty result, only GenerateComposedValue() does return a value. All locations testing a boolean of such a composed property now use the same approach, compare against the property name. Because of the rather strange storage format of a composed boolean and especially the difference to the format of a non-composed boolean comments about the storage format have been added. Parsing the default values of PT_PARENT child elements from a XML file now works properly with empty child tags.

This should fix at least #436