### PR TITLE
Use safer values for static WindowIDs and safer methods for dynamic WindowIDs

### DIFF
--- a/plugins/additional/additional.cpp
+++ b/plugins/additional/additional.cpp
@@ -101,10 +101,10 @@ protected:
 };
 
 BEGIN_EVENT_TABLE( ComponentEvtHandler, wxEvtHandler )
-	EVT_COLOURPICKER_CHANGED( -1, ComponentEvtHandler::OnColourPickerColourChanged )
-	EVT_FONTPICKER_CHANGED( -1, ComponentEvtHandler::OnFontPickerFontChanged )
-	EVT_FILEPICKER_CHANGED( -1, ComponentEvtHandler::OnFilePickerFileChanged )
-	EVT_DIRPICKER_CHANGED( -1, ComponentEvtHandler::OnDirPickerDirChanged )
+	EVT_COLOURPICKER_CHANGED(wxID_ANY, ComponentEvtHandler::OnColourPickerColourChanged)
+	EVT_FONTPICKER_CHANGED(wxID_ANY, ComponentEvtHandler::OnFontPickerFontChanged)
+	EVT_FILEPICKER_CHANGED(wxID_ANY, ComponentEvtHandler::OnFilePickerFileChanged)
+	EVT_DIRPICKER_CHANGED(wxID_ANY, ComponentEvtHandler::OnDirPickerDirChanged)
 	EVT_TEXT( wxID_ANY, ComponentEvtHandler::OnText )
 
 	// Grid also seems to ignore clicks
@@ -115,8 +115,8 @@ BEGIN_EVENT_TABLE( ComponentEvtHandler, wxEvtHandler )
 	EVT_GRID_ROW_SIZE( ComponentEvtHandler::OnGridRowSize )
 
 #if wxVERSION_NUMBER >= 2904
-	EVT_STC_MARGINCLICK( -1, ComponentEvtHandler::OnMarginClick )
-	EVT_RIBBONBAR_PAGE_CHANGED( -1, ComponentEvtHandler::OnRibbonBarPageChanged )
+	EVT_STC_MARGINCLICK(wxID_ANY, ComponentEvtHandler::OnMarginClick)
+	EVT_RIBBONBAR_PAGE_CHANGED(wxID_ANY, ComponentEvtHandler::OnRibbonBarPageChanged)
 #endif
 END_EVENT_TABLE()
 
@@ -153,7 +153,7 @@ class CalendarCtrlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxCalendarCtrl((wxWindow *)parent,-1,
+		return new wxCalendarCtrl((wxWindow *)parent, wxID_ANY,
 			wxDefaultDateTime,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -178,7 +178,7 @@ class DatePickerCtrlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxDatePickerCtrl((wxWindow *)parent,-1,
+		return new wxDatePickerCtrl((wxWindow *)parent, wxID_ANY,
 			wxDefaultDateTime,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -202,7 +202,7 @@ class TimePickerCtrlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxTimePickerCtrl( ( wxWindow * )parent, -1,
+		return new wxTimePickerCtrl( ( wxWindow * )parent, wxID_ANY,
 									 wxDefaultDateTime,
 									 obj->GetPropertyAsPoint( _( "pos" ) ),
 									 obj->GetPropertyAsSize( _( "size" ) ),
@@ -386,7 +386,7 @@ class HtmlWindowComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxHtmlWindow *hw = new wxHtmlWindow((wxWindow *)parent,-1,
+		wxHtmlWindow *hw = new wxHtmlWindow((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -420,7 +420,7 @@ class ToggleButtonComponent : public ComponentBase, public wxEvtHandler
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxToggleButton* window = new wxToggleButton((wxWindow *)parent,-1,
+		wxToggleButton* window = new wxToggleButton((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("label")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -475,7 +475,7 @@ class TreeCtrlComponent : public ComponentBase
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		int style = obj->GetPropertyAsInteger(_("style"));
-		wxTreeCtrl *tc = new wxTreeCtrl((wxWindow *)parent,-1,
+		wxTreeCtrl *tc = new wxTreeCtrl((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			style | obj->GetPropertyAsInteger(_("window_style")));
@@ -513,7 +513,7 @@ class ScrollBarComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxScrollBar *sb = new wxScrollBar((wxWindow *)parent,-1,
+		wxScrollBar *sb = new wxScrollBar((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -552,7 +552,7 @@ public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		int max = obj->GetPropertyAsInteger(_("max"));
 		int min = obj->GetPropertyAsInteger(_("min"));
-		wxSpinCtrl* window = new wxSpinCtrl((wxWindow *)parent,-1,
+		wxSpinCtrl* window = new wxSpinCtrl((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("value")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -611,7 +611,7 @@ class SpinCtrlDoubleComponent : public ComponentBase, public wxEvtHandler
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxSpinCtrlDouble* window = new wxSpinCtrlDouble((wxWindow *)parent, -1,
+		wxSpinCtrlDouble* window = new wxSpinCtrlDouble((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("value")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -677,7 +677,7 @@ class SpinButtonComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxSpinButton((wxWindow *)parent,-1,
+		return new wxSpinButton((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -702,7 +702,7 @@ public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		wxArrayString choices (obj->GetPropertyAsArrayString(_("choices")));
 		wxCheckListBox *cl =
-			new wxCheckListBox((wxWindow *)parent,-1,
+			new wxCheckListBox((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			choices,
@@ -730,7 +730,7 @@ class GridComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxGrid *grid = new wxGrid((wxWindow *)parent,-1,
+		wxGrid *grid = new wxGrid((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("window_style")));
@@ -1125,7 +1125,7 @@ class HyperlinkComponent : public ComponentBase
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		wxHyperlinkCtrl* ctrl = new wxHyperlinkCtrl(
-			(wxWindow*)parent, -1,
+			(wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("label")),
 			obj->GetPropertyAsString(_("url")),
 			obj->GetPropertyAsPoint(_("pos")),
@@ -1226,7 +1226,7 @@ class CustomControlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* /*obj*/, wxObject* parent) override {
-		return new wxPanel((wxWindow *)parent, -1, wxDefaultPosition, wxDefaultSize, 0 );
+		return new wxPanel((wxWindow *)parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0 );
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -1353,7 +1353,7 @@ class PropertyGridComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxPropertyGrid* pg = new wxPropertyGrid((wxWindow *)parent,-1,
+		wxPropertyGrid* pg = new wxPropertyGrid((wxWindow *)parent, wxID_ANY,
 												obj->GetPropertyAsPoint(wxT("pos")),
 												obj->GetPropertyAsSize(wxT("size")),
 												obj->GetPropertyAsInteger(wxT("style")) |
@@ -1415,7 +1415,7 @@ class PropertyGridManagerComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxPropertyGridManager* pgman = new wxPropertyGridManager((wxWindow *)parent, -1,
+		wxPropertyGridManager* pgman = new wxPropertyGridManager((wxWindow *)parent, wxID_ANY,
 																obj->GetPropertyAsPoint(wxT("pos")),
 																obj->GetPropertyAsSize(wxT("size")),
 																obj->GetPropertyAsInteger(wxT("style")) |
@@ -1587,7 +1587,7 @@ class StyledTextComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxStyledTextCtrl* m_code = new wxStyledTextCtrl( 	(wxWindow *)parent, -1,
+		wxStyledTextCtrl* m_code = new wxStyledTextCtrl( 	(wxWindow *)parent, wxID_ANY,
 												obj->GetPropertyAsPoint(_("pos")),
 												obj->GetPropertyAsSize(_("size")),
 												obj->GetPropertyAsInteger(_("window_style")),
@@ -1881,7 +1881,7 @@ class wxcoreTreeListCtrlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxTreeListCtrl* treeListCtrl = new wxTreeListCtrl( (wxWindow *)parent, -1,
+		wxTreeListCtrl* treeListCtrl = new wxTreeListCtrl( (wxWindow *)parent, wxID_ANY,
 				obj->GetPropertyAsPoint(_("pos")),
 				obj->GetPropertyAsSize(_("size")),
 				obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));

--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -181,7 +181,7 @@ class ButtonComponent : public ComponentBase
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		wxString label = obj->GetPropertyAsString( _("label") );
-		wxButton* button = new wxButton((wxWindow*)parent, -1,
+		wxButton* button = new wxButton((wxWindow*)parent, wxID_ANY,
 			label,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -280,7 +280,7 @@ class BitmapButtonComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxBitmapButton* button = new wxBitmapButton((wxWindow*)parent,-1,
+		wxBitmapButton* button = new wxBitmapButton((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsBitmap(_("bitmap")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -377,7 +377,7 @@ class TextCtrlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxTextCtrl* tc = new wxTextCtrl((wxWindow *)parent,-1,
+		wxTextCtrl* tc = new wxTextCtrl((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("value")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -439,7 +439,7 @@ class StaticTextComponent : public ComponentBase
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		wxString label = obj->GetPropertyAsString( _("label") );
-		wxStaticText* st = new wxStaticText((wxWindow *)parent, -1,
+		wxStaticText* st = new wxStaticText((wxWindow *)parent, wxID_ANY,
 			label,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -479,7 +479,7 @@ class ComboBoxComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxComboBox *combo = new wxComboBox((wxWindow *)parent,-1,
+		wxComboBox *combo = new wxComboBox((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("value")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -522,7 +522,7 @@ class BitmapComboBoxComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxBitmapComboBox *bcombo = new wxBitmapComboBox((wxWindow *)parent,-1,
+		wxBitmapComboBox *bcombo = new wxBitmapComboBox((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("value")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -567,7 +567,7 @@ class CheckBoxComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxCheckBox *res = new wxCheckBox((wxWindow *)parent,-1,
+		wxCheckBox *res = new wxCheckBox((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("label")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -612,7 +612,7 @@ class StaticBitmapComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxStaticBitmap((wxWindow *)parent,-1,
+		return new wxStaticBitmap((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsBitmap(_("bitmap")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -642,7 +642,7 @@ class StaticLineComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxStaticLine((wxWindow *)parent,-1,
+		return new wxStaticLine((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -665,7 +665,7 @@ class ListCtrlComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxListCtrl *lc = new wxListCtrl((wxWindow*)parent, -1,
+		wxListCtrl *lc = new wxListCtrl((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			(obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style"))) & ~wxLC_VIRTUAL);
@@ -718,7 +718,7 @@ class ListBoxComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxListBox *listbox = new wxListBox((wxWindow*)parent, -1,
+		wxListBox *listbox = new wxListBox((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			0,
@@ -768,7 +768,7 @@ public:
 			majorDim = 1;
 		}
 
-		wxRadioBox *radiobox = new wxRadioBox((wxWindow*)parent, -1,
+		wxRadioBox *radiobox = new wxRadioBox((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("label")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -835,7 +835,7 @@ class RadioButtonComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxRadioButton *rb = new wxRadioButton((wxWindow *)parent,-1,
+		wxRadioButton *rb = new wxRadioButton((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("label")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
@@ -866,7 +866,7 @@ class StatusBarComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxStatusBar *sb = new wxIndependentStatusBar((wxWindow*)parent, -1,
+		wxStatusBar *sb = new wxIndependentStatusBar((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
 		sb->SetFieldsCount(obj->GetPropertyAsInteger(_("fields")));
 
@@ -1030,7 +1030,7 @@ class ToolBarComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxToolBar *tb = new wxToolBar((wxWindow*)parent, -1,
+		wxToolBar *tb = new wxToolBar((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")) | wxTB_NOALIGN | wxTB_NODIVIDER | wxNO_BORDER);
@@ -1242,7 +1242,7 @@ class AuiToolBarComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		AuiToolBar *tb = new AuiToolBar((wxWindow*)parent, GetManager(), -1,
+		AuiToolBar *tb = new AuiToolBar((wxWindow*)parent, GetManager(), wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) );// | obj->GetPropertyAsInteger(_("window_style")) | wxTB_NOALIGN | wxTB_NODIVIDER | wxNO_BORDER);
@@ -1435,7 +1435,7 @@ public:
 		for (unsigned int i=0; i < choices.GetCount(); i++)
 			strings[i] = choices[i];
 
-		wxChoice *choice = new wxChoice((wxWindow*)parent, -1,
+		wxChoice *choice = new wxChoice((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			(int)choices.Count(),
@@ -1498,7 +1498,7 @@ class SliderComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxSlider((wxWindow *)parent,-1,
+		return new wxSlider((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsInteger(_("value")),
 			obj->GetPropertyAsInteger(_("minValue")),
 			obj->GetPropertyAsInteger(_("maxValue")),
@@ -1531,7 +1531,7 @@ class GaugeComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxGauge *gauge = new wxGauge((wxWindow *)parent,-1,
+		wxGauge *gauge = new wxGauge((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsInteger(_("range")),
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),

--- a/plugins/containers/containers.cpp
+++ b/plugins/containers/containers.cpp
@@ -120,15 +120,15 @@ protected:
 
 BEGIN_EVENT_TABLE( ComponentEvtHandler, wxEvtHandler )
 #ifdef wxUSE_COLLPANE
-	EVT_COLLAPSIBLEPANE_CHANGED( -1, ComponentEvtHandler::OnCollapsiblePaneChanged )
+	EVT_COLLAPSIBLEPANE_CHANGED(wxID_ANY, ComponentEvtHandler::OnCollapsiblePaneChanged)
 #endif
-	EVT_NOTEBOOK_PAGE_CHANGED( -1, ComponentEvtHandler::OnNotebookPageChanged )
-	EVT_LISTBOOK_PAGE_CHANGED( -1, ComponentEvtHandler::OnListbookPageChanged )
-	EVT_CHOICEBOOK_PAGE_CHANGED( -1, ComponentEvtHandler::OnChoicebookPageChanged )
-	EVT_AUINOTEBOOK_PAGE_CHANGED( -1, ComponentEvtHandler::OnAuiNotebookPageChanged )
-	EVT_AUINOTEBOOK_PAGE_CLOSE( -1, ComponentEvtHandler::OnAuiNotebookPageClosed )
-	EVT_AUINOTEBOOK_ALLOW_DND( -1, ComponentEvtHandler::OnAuiNotebookAllowDND )
-	EVT_SPLITTER_SASH_POS_CHANGED( -1, ComponentEvtHandler::OnSplitterSashChanged )
+	EVT_NOTEBOOK_PAGE_CHANGED(wxID_ANY, ComponentEvtHandler::OnNotebookPageChanged)
+	EVT_LISTBOOK_PAGE_CHANGED(wxID_ANY, ComponentEvtHandler::OnListbookPageChanged)
+	EVT_CHOICEBOOK_PAGE_CHANGED(wxID_ANY, ComponentEvtHandler::OnChoicebookPageChanged)
+	EVT_AUINOTEBOOK_PAGE_CHANGED(wxID_ANY, ComponentEvtHandler::OnAuiNotebookPageChanged)
+	EVT_AUINOTEBOOK_PAGE_CLOSE(wxID_ANY, ComponentEvtHandler::OnAuiNotebookPageClosed)
+	EVT_AUINOTEBOOK_ALLOW_DND(wxID_ANY, ComponentEvtHandler::OnAuiNotebookAllowDND)
+	EVT_SPLITTER_SASH_POS_CHANGED(wxID_ANY, ComponentEvtHandler::OnSplitterSashChanged)
 END_EVENT_TABLE()
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -207,7 +207,7 @@ class PanelComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxPanel* panel = new wxPanel((wxWindow *)parent,-1,
+		wxPanel* panel = new wxPanel((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -233,7 +233,7 @@ class CollapsiblePaneComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxCollapsiblePane* collpane = new wxCollapsiblePane( (wxWindow *)parent, -1,
+		wxCollapsiblePane* collpane = new wxCollapsiblePane( (wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString( _("label") ),
 			obj->GetPropertyAsPoint( _("pos") ),
 			obj->GetPropertyAsSize( _("size") ),
@@ -282,7 +282,7 @@ class SplitterWindowComponent : public ComponentBase
 {
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		wxCustomSplitterWindow *splitter =
-			new wxCustomSplitterWindow((wxWindow *)parent,-1,
+			new wxCustomSplitterWindow((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			(obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style"))) & ~wxSP_PERMIT_UNSPLIT );
@@ -462,7 +462,7 @@ class ScrolledWindowComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-        wxScrolledWindow *sw = new wxScrolledWindow((wxWindow *)parent, -1,
+        wxScrolledWindow *sw = new wxScrolledWindow((wxWindow *)parent, wxID_ANY,
             obj->GetPropertyAsPoint(_("pos")),
             obj->GetPropertyAsSize(_("size")),
             obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -500,7 +500,7 @@ class NotebookComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxNotebook* book = new wxCustomNotebook((wxWindow *)parent,-1,
+		wxNotebook* book = new wxCustomNotebook((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -567,7 +567,7 @@ class ListbookComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxListbook* book = new wxListbook((wxWindow *)parent,-1,
+		wxListbook* book = new wxListbook((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -648,7 +648,7 @@ class ChoicebookComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxChoicebook* book = new wxChoicebook((wxWindow *)parent,-1,
+		wxChoicebook* book = new wxChoicebook((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -708,7 +708,7 @@ class AuiNotebookComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxAuiNotebook* book = new wxAuiNotebook((wxWindow *)parent,-1,
+		wxAuiNotebook* book = new wxAuiNotebook((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
@@ -815,7 +815,7 @@ class SimplebookComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		return new wxSimplebook((wxWindow *)parent,-1,
+		return new wxSimplebook((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(_("pos")),
 			obj->GetPropertyAsSize(_("size")),
 			obj->GetPropertyAsInteger(_("window_style")));

--- a/plugins/forms/forms.cpp
+++ b/plugins/forms/forms.cpp
@@ -57,7 +57,7 @@ class FrameFormComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* /*obj*/, wxObject* parent) override {
-		wxPanel *panel = new wxPanel((wxWindow *)parent,-1);
+		wxPanel *panel = new wxPanel((wxWindow *)parent, wxID_ANY);
 		panel->SetBackgroundColour(wxColour(50,50,50));
 		return panel;
 	}
@@ -88,7 +88,7 @@ class PanelFormComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* /*obj*/, wxObject* parent) override {
-		wxPanel *panel = new wxPanel((wxWindow *)parent,-1);
+		wxPanel *panel = new wxPanel((wxWindow *)parent, wxID_ANY);
 		return panel;
 	}
 
@@ -109,7 +109,7 @@ class DialogFormComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* /*obj*/, wxObject* parent) override {
-		wxPanel *panel = new wxPanel((wxWindow *)parent,-1);
+		wxPanel *panel = new wxPanel((wxWindow *)parent, wxID_ANY);
 		return panel;
 	}
 
@@ -159,7 +159,7 @@ class ToolBarFormComponent : public ComponentBase
 {
 public:
 	wxObject* Create(IObject* obj, wxObject* parent) override {
-		wxToolBar *tb = new wxToolBar((wxWindow*)parent, -1,
+		wxToolBar *tb = new wxToolBar((wxWindow*)parent, wxID_ANY,
 			obj->GetPropertyAsPoint(wxT("pos")),
 			obj->GetPropertyAsSize(wxT("size")),
 			obj->GetPropertyAsInteger(wxT("style")) | obj->GetPropertyAsInteger(wxT("window_style")) | wxTB_NOALIGN | wxTB_NODIVIDER | wxNO_BORDER);

--- a/plugins/layout/layout.cpp
+++ b/plugins/layout/layout.cpp
@@ -233,7 +233,7 @@ public:
 	}
 	wxObject* Create(IObject* obj, wxObject* parent) override {
 		m_count++;
-		wxStaticBox* box = new wxStaticBox((wxWindow *)parent, -1,
+		wxStaticBox* box = new wxStaticBox((wxWindow *)parent, wxID_ANY,
 			obj->GetPropertyAsString(_("label")));
 
 		wxStaticBoxSizer* sizer = new wxStaticBoxSizer(box,

--- a/src/maingui.cpp
+++ b/src/maingui.cpp
@@ -244,7 +244,7 @@ int MyApp::OnRun()
 
 	config->SetPath( wxT("/") );
 
-	m_frame = new MainFrame( NULL ,-1, (int)style, wxPoint( x, y ), wxSize( w, h ) );
+	m_frame = new MainFrame( NULL ,wxID_ANY, (int)style, wxPoint( x, y ), wxSize( w, h ) );
 	if ( !justGenerate )
 	{
 		m_frame->Show( TRUE );

--- a/src/model/objectbase.h
+++ b/src/model/objectbase.h
@@ -377,7 +377,7 @@ public:
 	*
 	* if (plabel && ppos && psize && pstyle)
 	* {
-	*   wxButton *button = new wxButton(parent,-1,
+	*   wxButton *button = new wxButton(parent,wxID_ANY,
 	*    plabel->GetValueAsString(),
 	*    ppos->GetValueAsPoint(),
 	*    psize->GetValueAsSize(),
@@ -396,7 +396,7 @@ public:
 	*
 	* try
 	* {
-	*   wxButton *button = new wxButton(parent,-1,
+	*   wxButton *button = new wxButton(parent,wxID_ANY,
 	*     obj->GetProperty("label")->GetValueAsString(),
 	*     obj->GetProperty("pos")->GetValueAsPoint(),
 	*     obj->GetProperty("size")->GetValueAsSize(),

--- a/src/rad/about.cpp
+++ b/src/rad/about.cpp
@@ -30,17 +30,18 @@
 #include <wx/html/htmlwin.h>
 #include <wx/mimetype.h>
 
-#define ID_DEFAULT -1 // Default
+#if 0
 #define ID_OK 1000
 
 BEGIN_EVENT_TABLE(AboutDialog,wxDialog)
   EVT_BUTTON(ID_OK,AboutDialog::OnButtonEvent)
 END_EVENT_TABLE()
+#endif
 
 class HtmlWindow : public wxHtmlWindow
 {
   public:
-    HtmlWindow(wxWindow *parent) : wxHtmlWindow(parent, -1, wxDefaultPosition, wxDefaultSize,
+    HtmlWindow(wxWindow *parent) : wxHtmlWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
       wxHW_SCROLLBAR_NEVER | wxHW_NO_SELECTION | wxRAISED_BORDER)
     {
     }
@@ -71,29 +72,29 @@ AboutDialog::AboutDialog(wxWindow *parent, int id) : wxDialog(parent,id,wxT("Abo
 #if 0
   wxBoxSizer *sizer2;
   sizer2 = new wxBoxSizer(wxVERTICAL);
-  m_staticText2 = new wxStaticText(this,ID_DEFAULT,wxT("wxFormBuilder"),wxDefaultPosition,wxDefaultSize,0);
+  m_staticText2 = new wxStaticText(this,wxID_ANY,wxT("wxFormBuilder"),wxDefaultPosition,wxDefaultSize,0);
   m_staticText2->SetFont(wxFont(12,74,90,92,false,wxT("Arial")));
   sizer2->Add(m_staticText2, 0, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);
-  m_staticText3 = new wxStaticText(this,ID_DEFAULT,wxT("a RAD tool for wxWidgets framework"),wxDefaultPosition,wxDefaultSize,0);
+  m_staticText3 = new wxStaticText(this,wxID_ANY,wxT("a RAD tool for wxWidgets framework"),wxDefaultPosition,wxDefaultSize,0);
   sizer2->Add(m_staticText3, 0, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);
-  m_staticText6 = new wxStaticText(this,ID_DEFAULT,wxT("(C) 2005 José Antonio Hurtado"),wxDefaultPosition,wxDefaultSize,0);
+  m_staticText6 = new wxStaticText(this,wxID_ANY,wxT("(C) 2005 José Antonio Hurtado"),wxDefaultPosition,wxDefaultSize,0);
   sizer2->Add(m_staticText6, 0, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);
-  window1 = new wxStaticLine(this,ID_DEFAULT,wxDefaultPosition,wxDefaultSize,wxLI_HORIZONTAL);
+  window1 = new wxStaticLine(this,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxLI_HORIZONTAL);
   sizer2->Add(window1, 0, wxALL|wxEXPAND, 5);
-  m_panel1 = new wxPanel(this,ID_DEFAULT,wxDefaultPosition,wxDefaultSize,wxSUNKEN_BORDER|wxTAB_TRAVERSAL);
+  m_panel1 = new wxPanel(this,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxSUNKEN_BORDER|wxTAB_TRAVERSAL);
   wxBoxSizer *sizer3;
   sizer3 = new wxBoxSizer(wxVERTICAL);
-  m_staticText8 = new wxStaticText(m_panel1,ID_DEFAULT,wxT("Developed by:"),wxDefaultPosition,wxDefaultSize,0);
+  m_staticText8 = new wxStaticText(m_panel1,wxID_ANY,wxT("Developed by:"),wxDefaultPosition,wxDefaultSize,0);
   sizer3->Add(m_staticText8, 0, wxALL, 5);
-  m_staticText9 = new wxStaticText(m_panel1,ID_DEFAULT,wxT("- José Antonio Hurtado"),wxDefaultPosition,wxDefaultSize,0);
+  m_staticText9 = new wxStaticText(m_panel1,wxID_ANY,wxT("- José Antonio Hurtado"),wxDefaultPosition,wxDefaultSize,0);
   sizer3->Add(m_staticText9, 0, wxALL, 5);
-  m_staticText10 = new wxStaticText(m_panel1,ID_DEFAULT,wxT("- Juan Antonio Ortega"),wxDefaultPosition,wxDefaultSize,0);
+  m_staticText10 = new wxStaticText(m_panel1,wxID_ANY,wxT("- Juan Antonio Ortega"),wxDefaultPosition,wxDefaultSize,0);
   sizer3->Add(m_staticText10, 0, wxALL, 5);
   m_panel1->SetSizer(sizer3);
   m_panel1->SetAutoLayout(true);
   m_panel1->Layout();
   sizer2->Add(m_panel1, 1, wxALL|wxEXPAND, 5);
-  window2 = new wxStaticLine(this,ID_DEFAULT,wxDefaultPosition,wxDefaultSize,wxLI_HORIZONTAL);
+  window2 = new wxStaticLine(this,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxLI_HORIZONTAL);
   sizer2->Add(window2, 0, wxALL|wxEXPAND, 5);
   m_button1 = new wxButton(this,ID_OK,wxT("&OK"),wxDefaultPosition,wxDefaultSize,0);
   sizer2->Add(m_button1, 0, wxALL|wxALIGN_CENTER_HORIZONTAL, 5);

--- a/src/rad/about.h
+++ b/src/rad/about.h
@@ -49,11 +49,13 @@ class AboutDialog : public wxDialog
     wxStaticLine *window2;
     wxButton *m_button1;
     
-    DECLARE_EVENT_TABLE()
+	#if 0
+	DECLARE_EVENT_TABLE()
+	#endif
   
   public:
     
-    AboutDialog(wxWindow *parent, int id = -1);
+    AboutDialog(wxWindow *parent, int id = wxID_ANY);
     void OnButtonEvent (wxCommandEvent &event);
   
 };

--- a/src/rad/cpppanel/cpppanel.cpp
+++ b/src/rad/cpppanel/cpppanel.cpp
@@ -65,15 +65,15 @@ wxPanel( parent, id )
 	AppData()->AddHandler( this->GetEventHandler() );
 	wxBoxSizer *top_sizer = new wxBoxSizer( wxVERTICAL );
 
-	m_notebook = new wxAuiNotebook( this, -1, wxDefaultPosition, wxDefaultSize, wxAUI_NB_TOP );
+	m_notebook = new wxAuiNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_NB_TOP );
 	m_notebook->SetArtProvider( new AuiTabArt() );
 
-	m_cppPanel = new CodeEditor( m_notebook, -1 );
+	m_cppPanel = new CodeEditor( m_notebook, wxID_ANY);
 	InitStyledTextCtrl( m_cppPanel->GetTextCtrl() );
 	m_notebook->AddPage( m_cppPanel, wxT( "cpp" ), false, 0 );
 	m_notebook->SetPageBitmap( 0, AppBitmaps::GetBitmap( wxT( "cpp" ), 16 ) );
 
-	m_hPanel = new CodeEditor( m_notebook, -1 );
+	m_hPanel = new CodeEditor( m_notebook, wxID_ANY);
 	InitStyledTextCtrl( m_hPanel->GetTextCtrl() );
 	m_notebook->AddPage( m_hPanel, wxT( "h" ), false, 1 );
 	m_notebook->SetPageBitmap( 1, AppBitmaps::GetBitmap( wxT( "h" ), 16 ) );

--- a/src/rad/designer/innerframe.cpp
+++ b/src/rad/designer/innerframe.cpp
@@ -286,8 +286,8 @@ wxInnerFrame::wxInnerFrame( wxWindow *parent, wxWindowID id,
 	m_curX = m_curY = -1;
 	m_resizeBorder = 10;
 
-	m_titleBar = new TitleBar( this, -1, wxDefaultPosition, wxDefaultSize, style );
-	m_frameContent = new wxPanel( this, -1, wxDefaultPosition, wxDefaultSize );
+	m_titleBar = new TitleBar( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, style );
+	m_frameContent = new wxPanel( this, wxID_ANY, wxDefaultPosition, wxDefaultSize );
 
 	// Use spacers to create a 1 pixel border on left and top of content panel - this is for drawing the selection box
 	// Use borders to create a 2 pixel border on right and bottom - this is so the back panel can catch mouse events for resizing

--- a/src/rad/designer/menubar.cpp
+++ b/src/rad/designer/menubar.cpp
@@ -36,7 +36,7 @@ Menubar::Menubar(wxWindow *parent, int id, const wxPoint& pos, const wxSize &siz
 {
     wxBoxSizer *mainSizer = new wxBoxSizer(wxVERTICAL);
     m_sizer = new wxBoxSizer(wxHORIZONTAL);
-    m_sizer->Add(new wxStaticText(this, -1, wxT(" ")), 0, wxRIGHT | wxLEFT, 0);
+    m_sizer->Add(new wxStaticText(this, wxID_ANY, wxT(" ")), 0, wxRIGHT | wxLEFT, 0);
     mainSizer->Add(m_sizer, 1, wxTOP | wxBOTTOM, 3);
     SetSizer(mainSizer);
     SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNFACE));
@@ -68,7 +68,7 @@ Menubar::~Menubar()
 
 void Menubar::AppendMenu(const wxString& name, wxMenu *menu)
 {
-    wxStaticText *st = new wxStaticText(this, -1, name);
+    wxStaticText *st = new wxStaticText(this, wxID_ANY, name);
     st->PushEventHandler(new MenuEvtHandler(st, menu));
     m_sizer->Add(st, 0, wxALIGN_LEFT | wxRIGHT | wxLEFT, 5);
     Layout();

--- a/src/rad/designer/visualeditor.cpp
+++ b/src/rad/designer/visualeditor.cpp
@@ -39,11 +39,11 @@
 #define wxFULL_REPAINT_ON_RESIZE 0
 #endif
 
-static const int ID_TIMER_SCAN = wxNewId();
+static const int ID_TIMER_SCAN = wxWindow::NewControlId();
 
 BEGIN_EVENT_TABLE(VisualEditor,wxScrolledWindow)
-	//EVT_SASH_DRAGGED(-1, VisualEditor::OnResizeBackPanel)
-	//EVT_COMMAND(-1, wxEVT_PANEL_RESIZED, VisualEditor::OnResizeBackPanel)
+	//EVT_SASH_DRAGGED(wxID_ANY, VisualEditor::OnResizeBackPanel)
+	//EVT_COMMAND(wxID_ANY, wxEVT_PANEL_RESIZED, VisualEditor::OnResizeBackPanel)
 	EVT_INNER_FRAME_RESIZED(wxID_ANY, VisualEditor::OnResizeBackPanel)
 
 	EVT_FB_PROJECT_LOADED( VisualEditor::OnProjectLoaded )
@@ -61,7 +61,7 @@ END_EVENT_TABLE()
 
 VisualEditor::VisualEditor(wxWindow *parent)
 :
-wxScrolledWindow(parent,-1,wxDefaultPosition,wxDefaultSize,wxSUNKEN_BORDER),
+wxScrolledWindow(parent, wxID_ANY,wxDefaultPosition,wxDefaultSize,wxSUNKEN_BORDER),
 m_stopSelectedEvent( false ),
 m_stopModifiedEvent( false )
 {
@@ -1538,7 +1538,7 @@ void DesignerWindow::SetFrameWidgets(PObjectBase menubar, wxWindow *toolbar, wxW
 
 	if ( menubar )
 	{
-		mbWidget = new Menubar(contentPanel, -1);
+		mbWidget = new Menubar(contentPanel, wxID_ANY);
 		for ( unsigned int i = 0; i < menubar->GetChildCount(); i++ )
 		{
 			PObjectBase menu = menubar->GetChild( i );
@@ -1556,7 +1556,7 @@ void DesignerWindow::SetFrameWidgets(PObjectBase menubar, wxWindow *toolbar, wxW
 	if ( mbWidget )
 	{
 		dummySizer->Add(mbWidget, 0, wxEXPAND | wxTOP | wxBOTTOM, 0);
-		dummySizer->Add(new wxStaticLine(contentPanel, -1), 0, wxEXPAND | wxALL, 0);
+		dummySizer->Add(new wxStaticLine(contentPanel, wxID_ANY), 0, wxEXPAND | wxALL, 0);
 	}
 
 	wxSizer* contentSizer = dummySizer;

--- a/src/rad/genericpanel.cpp
+++ b/src/rad/genericpanel.cpp
@@ -30,7 +30,7 @@ BEGIN_EVENT_TABLE(GenericWindow,wxPanel)
 END_EVENT_TABLE()
 
 GenericWindow::GenericWindow(wxWindow *parent)
-  : wxPanel (parent, -1,wxDefaultPosition,wxSize(30,30))
+  : wxPanel (parent, wxID_ANY,wxDefaultPosition,wxSize(30,30))
 {
 }
 

--- a/src/rad/inspector/objinspect.cpp
+++ b/src/rad/inspector/objinspect.cpp
@@ -44,8 +44,10 @@
 
 static int wxEVT_FB_PROP_BITMAP_CHANGED = wxNewEventType();
 
-#define WXFB_PROPERTY_GRID 1000
-#define WXFB_EVENT_GRID    1001
+enum {
+	WXFB_PROPERTY_GRID = wxID_HIGHEST + 1000,
+	WXFB_EVENT_GRID,
+};
 
 // -----------------------------------------------------------------------
 // ObjectInspector

--- a/src/rad/inspector/wxfbadvprops.cpp
+++ b/src/rad/inspector/wxfbadvprops.cpp
@@ -789,10 +789,9 @@ wxPGWindowList wxPGSliderEditor::CreateControls( wxPropertyGrid* propgrid,
         else if ( v_d > 1 )
             v_d = 1;
     }
-    int sliderId = wxNewId();
 
     ctrl->Create( propgrid->GetPanel(),
-                  sliderId,
+                  wxID_ANY,
                   (int)(v_d * m_max),
                   0,
                   m_max,

--- a/src/rad/luapanel/luapanel.cpp
+++ b/src/rad/luapanel/luapanel.cpp
@@ -64,7 +64,7 @@ wxPanel( parent, id )
 	AppData()->AddHandler( this->GetEventHandler() );
 	wxBoxSizer *top_sizer = new wxBoxSizer( wxVERTICAL );
 
-	m_luaPanel = new CodeEditor( this, -1 );
+	m_luaPanel = new CodeEditor( this, wxID_ANY);
 	InitStyledTextCtrl( m_luaPanel->GetTextCtrl() );
 
 	top_sizer->Add( m_luaPanel, 1, wxEXPAND, 0 );

--- a/src/rad/mainframe.cpp
+++ b/src/rad/mainframe.cpp
@@ -47,57 +47,60 @@
 #include "wxfbmanager.h"
 #include "xrcpanel/xrcpanel.h"
 
-#define ID_SAVE_PRJ      102
-#define ID_OPEN_PRJ      103
-#define ID_NEW_PRJ       104
-#define ID_GENERATE_CODE 105
-#define ID_IMPORT_XRC    106
-#define ID_UNDO          107
-#define ID_REDO          108
-#define ID_SAVE_AS_PRJ   109
-#define ID_CUT           110
-#define ID_DELETE        111
-#define ID_COPY          112
-#define ID_PASTE         113
-#define ID_EXPAND        114
-#define ID_STRETCH       115
-#define ID_MOVE_UP       116
-#define ID_MOVE_DOWN     117
-#define ID_RECENT_0      118 // Tienen que tener ids consecutivos
-#define ID_RECENT_1      119 // ID_RECENT_n+1 == ID_RECENT_n + 1
-#define ID_RECENT_2      120 //
-#define ID_RECENT_3      121 //
-#define ID_RECENT_SEP    122
+enum
+{
+	ID_SAVE_PRJ = wxID_HIGHEST + 1,
+	ID_OPEN_PRJ,
+	ID_NEW_PRJ,
+	ID_GENERATE_CODE,
+	ID_IMPORT_XRC,
+	ID_UNDO,
+	ID_REDO,
+	ID_SAVE_AS_PRJ,
+	ID_CUT,
+	ID_DELETE,
+	ID_COPY,
+	ID_PASTE,
+	ID_EXPAND,
+	ID_STRETCH,
+	ID_MOVE_UP,
+	ID_MOVE_DOWN,
+	ID_RECENT_0, // Tienen que tener ids consecutivos
+	ID_RECENT_1, // ID_RECENT_n+1 == ID_RECENT_n + 1
+	ID_RECENT_2, //
+	ID_RECENT_3, //
+	ID_RECENT_SEP,
+	
+	ID_ALIGN_LEFT,
+	ID_ALIGN_CENTER_H,
+	ID_ALIGN_RIGHT,
+	ID_ALIGN_TOP,
+	ID_ALIGN_CENTER_V,
+	ID_ALIGN_BOTTOM,
+	
+	ID_BORDER_LEFT,
+	ID_BORDER_RIGHT,
+	ID_BORDER_TOP,
+	ID_BORDER_BOTTOM,
+	ID_EDITOR_FNB,
+	ID_MOVE_LEFT,
+	ID_MOVE_RIGHT,
+	
+	ID_PREVIEW_XRC,
+	ID_GEN_INHERIT_CLS,
 
-#define ID_ALIGN_LEFT     123
-#define ID_ALIGN_CENTER_H 124
-#define ID_ALIGN_RIGHT    125
-#define ID_ALIGN_TOP      126
-#define ID_ALIGN_CENTER_V 127
-#define ID_ALIGN_BOTTOM   128
-
-#define ID_BORDER_LEFT    129
-#define ID_BORDER_RIGHT   130
-#define ID_BORDER_TOP     131
-#define ID_BORDER_BOTTOM  132
-#define ID_EDITOR_FNB	  133
-#define ID_MOVE_LEFT	  134
-#define ID_MOVE_RIGHT     135
-
-#define ID_PREVIEW_XRC     136
-#define ID_GEN_INHERIT_CLS 137
-
-// The preference dialog must use wxID_PREFERENCES for wxMAC
-//#define ID_SETTINGS_GLOBAL 138	// For the future preference dialogs
-#define ID_SETTINGS_PROJ   139	// For the future preference dialogs
-
-#define ID_FIND 142
-
-#define ID_CLIPBOARD_COPY 143
-#define ID_CLIPBOARD_PASTE 144
-
-//added by tyysoft to define the swap button ID.
-#define ID_WINDOW_SWAP 200
+	// The preference dialog must use wxID_PREFERENCES for wxMAC
+	//ID_SETTINGS_GLOBAL, // For the future preference dialogs
+	ID_SETTINGS_PROJ, // For the future preference dialogs
+	
+	ID_FIND,
+	
+	ID_CLIPBOARD_COPY,
+	ID_CLIPBOARD_PASTE,
+	
+	//added by tyysoft to define the swap button ID.
+	ID_WINDOW_SWAP,
+};
 
 #define STATUS_FIELD_OBJECT 2
 #define STATUS_FIELD_PATH 1
@@ -1588,23 +1591,23 @@ wxWindow * MainFrame::CreateDesignerWindow( wxWindow *parent )
 	m_notebook->AddPage( m_visualEdit, wxT( "Designer" ), false, 0 );
 	m_notebook->SetPageBitmap( 0, AppBitmaps::GetBitmap( wxT( "designer" ), 16 ) );
 
-	m_cpp = new CppPanel( m_notebook, -1 );
+	m_cpp = new CppPanel( m_notebook, wxID_ANY);
 	m_notebook->AddPage( m_cpp, wxT( "C++" ), false, 1 );
 	m_notebook->SetPageBitmap( 1, AppBitmaps::GetBitmap( wxT( "c++" ), 16 ) );
 
-	m_python = new PythonPanel( m_notebook, -1 );
+	m_python = new PythonPanel( m_notebook, wxID_ANY);
 	m_notebook->AddPage( m_python, wxT( "Python" ), false, 2 );
 	m_notebook->SetPageBitmap( 2, AppBitmaps::GetBitmap( wxT( "python" ), 16 ) );
 
-	m_php = new PHPPanel( m_notebook, -1 );
+	m_php = new PHPPanel( m_notebook, wxID_ANY);
 	m_notebook->AddPage( m_php, wxT( "PHP" ), false, 3 );
 	m_notebook->SetPageBitmap( 3, AppBitmaps::GetBitmap( wxT( "php" ), 16 ) );
 
-	m_lua = new LuaPanel(m_notebook, -1);
+	m_lua = new LuaPanel(m_notebook, wxID_ANY);
 	m_notebook->AddPage(m_lua,wxT( "Lua" ), false, 4 );
 	m_notebook->SetPageBitmap( 4, AppBitmaps::GetBitmap( wxT( "lua" ), 16 ) );
 
-	m_xrc = new XrcPanel( m_notebook, -1 );
+	m_xrc = new XrcPanel( m_notebook, wxID_ANY);
 	m_notebook->AddPage( m_xrc, wxT( "XRC" ), false, 5 );
 	m_notebook->SetPageBitmap( 5, AppBitmaps::GetBitmap( wxT( "xrc" ), 16 ) );
 
@@ -1615,7 +1618,7 @@ wxWindow * MainFrame::CreateComponentPalette ( wxWindow *parent )
 {
 	// la paleta de componentes, no es un observador propiamente dicho, ya
 	// que no responde ante los eventos de la aplicación
-	m_palette = new wxFbPalette( parent, -1 );
+	m_palette = new wxFbPalette( parent, wxID_ANY);
 	m_palette->Create();
 	//m_palette->SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_3DFACE ) );
 
@@ -1624,7 +1627,7 @@ wxWindow * MainFrame::CreateComponentPalette ( wxWindow *parent )
 
 wxWindow * MainFrame::CreateObjectTree( wxWindow *parent )
 {
-	m_objTree = new ObjectTree( parent, -1 );
+	m_objTree = new ObjectTree( parent, wxID_ANY);
 	m_objTree->Create();
 
 	return m_objTree;
@@ -1634,7 +1637,7 @@ wxWindow * MainFrame::CreateObjectInspector( wxWindow *parent )
 {
 	//TO-DO: make object inspector style selectable.
 	int style = ( m_style == wxFB_CLASSIC_GUI ? wxFB_OI_MULTIPAGE_STYLE : wxFB_OI_SINGLE_PAGE_STYLE );
-	m_objInsp = new ObjectInspector( parent, -1, style );
+	m_objInsp = new ObjectInspector( parent, wxID_ANY, style );
 	return m_objInsp;
 }
 
@@ -1646,7 +1649,7 @@ void MainFrame::CreateWideGui()
 	wxWindow *objectTree = Title::CreateTitle( CreateObjectTree( m_leftSplitter ), wxT( "Object Tree" ) );
 
 	// panel1 contains Palette and splitter2 (m_rightSplitter)
-	wxPanel *panel1 = new wxPanel( m_leftSplitter, -1 );
+	wxPanel *panel1 = new wxPanel( m_leftSplitter, wxID_ANY);
 
 	wxWindow *palette = Title::CreateTitle( CreateComponentPalette( panel1 ), wxT( "Component Palette" ) );
 	m_rightSplitter   =  new wxSplitterWindow( panel1, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
@@ -1688,14 +1691,14 @@ void MainFrame::CreateWideGui()
 void MainFrame::CreateClassicGui()
 {
 	// Give ID to left splitter
-	//m_leftSplitter = new wxSplitterWindow( this, -1, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
+	//m_leftSplitter = new wxSplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
 	m_leftSplitter = new wxSplitterWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
 	m_rightSplitter =  new wxSplitterWindow( m_leftSplitter, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxSP_LIVE_UPDATE );
 	wxWindow *objectTree      = Title::CreateTitle( CreateObjectTree( m_rightSplitter ), wxT( "Object Tree" ) );
 	wxWindow *objectInspector = Title::CreateTitle( CreateObjectInspector( m_rightSplitter ), wxT( "Object Properties" ) );
 
 	// panel1 contains palette and designer
-	wxPanel *panel1 = new wxPanel( m_leftSplitter, -1 );
+	wxPanel *panel1 = new wxPanel( m_leftSplitter, wxID_ANY);
 
 	wxWindow *palette = Title::CreateTitle( CreateComponentPalette( panel1 ), wxT( "Component Palette" ) );
 	wxWindow *designer = Title::CreateTitle( CreateDesignerWindow( panel1 ), wxT( "Editor" ) );

--- a/src/rad/mainframe.h
+++ b/src/rad/mainframe.h
@@ -109,7 +109,7 @@ class MainFrame : public wxFrame
 
   DECLARE_EVENT_TABLE()
  public:
-  MainFrame(wxWindow *parent, int id = -1, int style = wxFB_DEFAULT_GUI, wxPoint pos = wxDefaultPosition, wxSize size = wxSize( 1000, 800 ) );
+  MainFrame(wxWindow *parent, int id = wxID_ANY, int style = wxFB_DEFAULT_GUI, wxPoint pos = wxDefaultPosition, wxSize size = wxSize( 1000, 800 ) );
 	~MainFrame() override;
   void RestorePosition(const wxString &name);
   void SavePosition(const wxString &name);

--- a/src/rad/menueditor.cpp
+++ b/src/rad/menueditor.cpp
@@ -27,16 +27,18 @@
 
 #include "../model/objectbase.h"
 
-#define ID_DEFAULT -1 // Default
-#define ID_ADDMENUITEM 1000
-#define ID_ADDSEPARATOR 1001
-#define ID_MENUDOWN 1002
-#define ID_MENULEFT 1003
-#define ID_MENURIGHT 1004
-#define ID_MENUUP 1005
-#define ID_REMOVEMENUITEM 1006
-#define ID_LABEL 1007
-#define ID_MODIFYMENUITEM 1008
+enum
+{
+	ID_ADDMENUITEM = wxID_HIGHEST + 1,
+	ID_ADDSEPARATOR,
+	ID_MENUDOWN,
+	ID_MENULEFT,
+	ID_MENURIGHT,
+	ID_MENUUP,
+	ID_REMOVEMENUITEM,
+	ID_LABEL,
+	ID_MODIFYMENUITEM,
+};
 
 #define IDENTATION 4
 
@@ -50,9 +52,9 @@ BEGIN_EVENT_TABLE(MenuEditor, wxDialog)
     EVT_BUTTON(ID_MENURIGHT, MenuEditor::OnMenuRight)
     EVT_BUTTON(ID_MENUUP, MenuEditor::OnMenuUp)
     EVT_UPDATE_UI_RANGE(ID_MENUDOWN, ID_MENUUP, MenuEditor::OnUpdateMovers)
-    EVT_TEXT_ENTER(-1, MenuEditor::OnEnter)
+    EVT_TEXT_ENTER(wxID_ANY, MenuEditor::OnEnter)
     EVT_TEXT(ID_LABEL, MenuEditor::OnLabelChanged)
-    EVT_LIST_ITEM_ACTIVATED(-1, MenuEditor::OnItemActivated)
+    EVT_LIST_ITEM_ACTIVATED(wxID_ANY, MenuEditor::OnItemActivated)
 END_EVENT_TABLE()
 
 MenuEditor::MenuEditor(wxWindow *parent, int id) : wxDialog(parent,id,wxT("Menu Editor"),wxDefaultPosition,wxDefaultSize)
@@ -61,7 +63,7 @@ MenuEditor::MenuEditor(wxWindow *parent, int id) : wxDialog(parent,id,wxT("Menu 
   mainSizer = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer *sizerTop;
   sizerTop = new wxBoxSizer(wxHORIZONTAL);
-  m_menuList = new wxListCtrl(this,ID_DEFAULT,wxDefaultPosition,wxDefaultSize,wxLC_REPORT | wxLC_SINGLE_SEL | wxSTATIC_BORDER);
+  m_menuList = new wxListCtrl(this,wxID_ANY,wxDefaultPosition,wxDefaultSize,wxLC_REPORT | wxLC_SINGLE_SEL | wxSTATIC_BORDER);
   m_menuList->InsertColumn(0, wxT("Label"), wxLIST_FORMAT_LEFT, 150);
   m_menuList->InsertColumn(1, wxT("Shortcut"), wxLIST_FORMAT_LEFT, 80);
   m_menuList->InsertColumn(2, wxT("Id"), wxLIST_FORMAT_LEFT, 80);
@@ -76,44 +78,44 @@ MenuEditor::MenuEditor(wxWindow *parent, int id) : wxDialog(parent,id,wxT("Menu 
   m_menuList->SetMinSize( wxSize( width, -1 ) );
   sizerTop->Add(m_menuList, 1, wxALL|wxEXPAND, 5);
   wxStaticBoxSizer *sizer1;
-  sizer1 = new wxStaticBoxSizer(new wxStaticBox(this, -1, wxT("Menu item")), wxVERTICAL);
+  sizer1 = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, wxT("Menu item")), wxVERTICAL);
 	const auto sizer11 = new wxFlexGridSizer(2, 0, 0);
   sizer11->AddGrowableCol(1);
 
   wxStaticText *m_stLabel;
-  m_stLabel = new wxStaticText(this,ID_DEFAULT,wxT("Label"),wxDefaultPosition,wxDefaultSize,0);
+  m_stLabel = new wxStaticText(this,wxID_ANY,wxT("Label"),wxDefaultPosition,wxDefaultSize,0);
   sizer11->Add(m_stLabel, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
   m_tcLabel = new wxTextCtrl(this,ID_LABEL,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
   sizer11->Add(m_tcLabel, 0, wxALL | wxEXPAND, 5);
 
   wxStaticText *m_stShortcut;
-  m_stShortcut = new wxStaticText(this,ID_DEFAULT,wxT("Shortcut"),wxDefaultPosition,wxDefaultSize,0);
+  m_stShortcut = new wxStaticText(this,wxID_ANY,wxT("Shortcut"),wxDefaultPosition,wxDefaultSize,0);
   sizer11->Add(m_stShortcut, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
   m_tcShortcut = new wxTextCtrl(this,ID_LABEL,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
   sizer11->Add(m_tcShortcut, 0, wxALL | wxEXPAND, 5);
 
   wxStaticText *m_stId;
-  m_stId = new wxStaticText(this,ID_DEFAULT,wxT("Id"),wxDefaultPosition,wxDefaultSize,0);
+  m_stId = new wxStaticText(this,wxID_ANY,wxT("Id"),wxDefaultPosition,wxDefaultSize,0);
   sizer11->Add(m_stId, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-  m_tcId = new wxTextCtrl(this,ID_DEFAULT,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
+  m_tcId = new wxTextCtrl(this,wxID_ANY,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
   sizer11->Add(m_tcId, 0, wxALL | wxEXPAND, 5);
 
   wxStaticText *m_stName;
-  m_stName = new wxStaticText(this,ID_DEFAULT,wxT("Name"),wxDefaultPosition,wxDefaultSize,0);
+  m_stName = new wxStaticText(this,wxID_ANY,wxT("Name"),wxDefaultPosition,wxDefaultSize,0);
   sizer11->Add(m_stName, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-  m_tcName = new wxTextCtrl(this,ID_DEFAULT,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
+  m_tcName = new wxTextCtrl(this,wxID_ANY,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
   sizer11->Add(m_tcName, 0, wxALL | wxEXPAND, 5);
 
   wxStaticText *m_stHelpString;
-  m_stHelpString = new wxStaticText(this,ID_DEFAULT,wxT("Help String"),wxDefaultPosition,wxDefaultSize,0);
+  m_stHelpString = new wxStaticText(this,wxID_ANY,wxT("Help String"),wxDefaultPosition,wxDefaultSize,0);
   sizer11->Add(m_stHelpString, 0, wxALL|wxALIGN_CENTER_VERTICAL, 5);
-  m_tcHelpString = new wxTextCtrl(this,ID_DEFAULT,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
+  m_tcHelpString = new wxTextCtrl(this,wxID_ANY,wxT(""),wxDefaultPosition,wxDefaultSize,wxTE_PROCESS_ENTER);
   sizer11->Add(m_tcHelpString, 0, wxALL | wxEXPAND, 5);
 
   sizer1->Add(sizer11, 0, wxALL | wxEXPAND, 0);
 
   wxString choices[] = {wxT("Normal"), wxT("Check"), wxT("Radio")};
-  m_rbItemKind = new wxRadioBox(this, -1, wxT("Kind"), wxDefaultPosition, wxDefaultSize,
+  m_rbItemKind = new wxRadioBox(this, wxID_ANY, wxT("Kind"), wxDefaultPosition, wxDefaultSize,
     3, choices, 1, wxRA_SPECIFY_ROWS);
   sizer1->Add(m_rbItemKind, 0, wxALL | wxEXPAND, 5);
 

--- a/src/rad/menueditor.h
+++ b/src/rad/menueditor.h
@@ -108,7 +108,7 @@ class MenuEditor : public wxDialog
   public:
 
     /** Constructor */
-    MenuEditor(wxWindow *parent, int id = -1);
+    MenuEditor(wxWindow *parent, int id = wxID_ANY);
 
     /** Rellena el wxListCtrl con los datos de "obj", que debe ser de tipo
     menubar */

--- a/src/rad/objecttree/objecttree.cpp
+++ b/src/rad/objecttree/objecttree.cpp
@@ -34,11 +34,11 @@
 #include <wx/imaglist.h>
 
 BEGIN_EVENT_TABLE( ObjectTree, wxPanel )
-	EVT_TREE_SEL_CHANGED( -1, ObjectTree::OnSelChanged )
-	EVT_TREE_ITEM_RIGHT_CLICK( -1, ObjectTree::OnRightClick )
-	EVT_TREE_BEGIN_DRAG( -1, ObjectTree::OnBeginDrag )
-	EVT_TREE_END_DRAG( -1, ObjectTree::OnEndDrag )
-	EVT_TREE_KEY_DOWN(-1, ObjectTree::OnKeyDown )
+	EVT_TREE_SEL_CHANGED(wxID_ANY, ObjectTree::OnSelChanged)
+	EVT_TREE_ITEM_RIGHT_CLICK(wxID_ANY, ObjectTree::OnRightClick)
+	EVT_TREE_BEGIN_DRAG(wxID_ANY, ObjectTree::OnBeginDrag)
+	EVT_TREE_END_DRAG(wxID_ANY, ObjectTree::OnEndDrag)
+	EVT_TREE_KEY_DOWN(wxID_ANY, ObjectTree::OnKeyDown)
 
 	EVT_FB_PROJECT_LOADED( ObjectTree::OnProjectLoaded )
 	EVT_FB_PROJECT_SAVED( ObjectTree::OnProjectSaved )
@@ -54,7 +54,7 @@ ObjectTree::ObjectTree( wxWindow *parent, int id )
 wxPanel( parent, id )
 {
 	AppData()->AddHandler( this->GetEventHandler() );
-	m_tcObjects = new wxTreeCtrl(this, -1, wxDefaultPosition, wxDefaultSize, wxTR_HAS_BUTTONS|wxTR_LINES_AT_ROOT|wxTR_DEFAULT_STYLE|wxSIMPLE_BORDER);
+	m_tcObjects = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTR_HAS_BUTTONS|wxTR_LINES_AT_ROOT|wxTR_DEFAULT_STYLE|wxSIMPLE_BORDER);
 
 	wxBoxSizer* sizer_1 = new wxBoxSizer(wxVERTICAL);
     sizer_1->Add(m_tcObjects, 1, wxEXPAND, 0);
@@ -553,21 +553,23 @@ ObjectTreeItemData::ObjectTreeItemData(PObjectBase obj) : m_object(obj)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-#define MENU_MOVE_UP    100
-#define MENU_MOVE_DOWN  101
-#define MENU_MOVE_RIGHT 102
-#define MENU_MOVE_LEFT  103
-#define MENU_CUT        104
-#define MENU_PASTE      105
-#define MENU_EDIT_MENUS 106
-#define MENU_COPY       107
-#define MENU_MOVE_NEW_BOXSIZER   108
-#define MENU_DELETE 109
+enum {
+	MENU_MOVE_UP = wxID_HIGHEST + 2000,
+	MENU_MOVE_DOWN,
+	MENU_MOVE_RIGHT,
+	MENU_MOVE_LEFT,
+	MENU_CUT,
+	MENU_PASTE,
+	MENU_EDIT_MENUS,
+	MENU_COPY,
+	MENU_MOVE_NEW_BOXSIZER,
+	MENU_DELETE,
+};
 
 
 BEGIN_EVENT_TABLE(ItemPopupMenu,wxMenu)
-	EVT_MENU(-1, ItemPopupMenu::OnMenuEvent)
-	EVT_UPDATE_UI(-1, ItemPopupMenu::OnUpdateEvent)
+	EVT_MENU(wxID_ANY, ItemPopupMenu::OnMenuEvent)
+	EVT_UPDATE_UI(wxID_ANY, ItemPopupMenu::OnUpdateEvent)
 END_EVENT_TABLE()
 
 ItemPopupMenu::ItemPopupMenu(PObjectBase obj)

--- a/src/rad/palette.cpp
+++ b/src/rad/palette.cpp
@@ -34,20 +34,18 @@
 	#include <wx/tooltip.h>
 #endif
 
-#define ID_PALETTE_BUTTON 999
-
 #define DRAG_OPTION 0
 
-wxWindowID wxFbPalette::nextId = wxID_HIGHEST + 1000;
+wxWindowID wxFbPalette::nextId = wxID_HIGHEST + 3000;
 
 BEGIN_EVENT_TABLE( wxFbPalette, wxPanel )
 	#ifdef __WXMAC__
-		EVT_BUTTON( -1, wxFbPalette::OnButtonClick )
+		EVT_BUTTON(wxID_ANY, wxFbPalette::OnButtonClick)
 	#else
-		EVT_TOOL(-1, wxFbPalette::OnButtonClick)
+		EVT_TOOL(wxID_ANY, wxFbPalette::OnButtonClick)
 	#endif
-	EVT_SPIN_UP( -1, wxFbPalette::OnSpinUp )
-	EVT_SPIN_DOWN( -1, wxFbPalette::OnSpinDown )
+	EVT_SPIN_UP(wxID_ANY, wxFbPalette::OnSpinUp)
+	EVT_SPIN_DOWN(wxID_ANY, wxFbPalette::OnSpinDown)
 END_EVENT_TABLE()
 
 wxFbPalette::wxFbPalette( wxWindow *parent, int id )
@@ -107,11 +105,11 @@ void wxFbPalette::Create()
 		PObjectPackage pkg = AppData()->GetPackage( i );
 		wxString pkg_name = pkg->GetPackageName();
 
-		wxPanel *panel = new wxPanel( m_notebook, -1 );
+		wxPanel *panel = new wxPanel( m_notebook, wxID_ANY);
 		//panel->SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_3DFACE ) );
 		wxBoxSizer *sizer = new wxBoxSizer( wxHORIZONTAL );
 
-		wxAuiToolBar *toolbar = new wxAuiToolBar( panel, -1, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW | wxNO_BORDER );
+		wxAuiToolBar *toolbar = new wxAuiToolBar( panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE | wxAUI_TB_OVERFLOW | wxNO_BORDER );
 		toolbar->SetToolBitmapSize( wxSize( 22, 22 ) );
 		PopulateToolbar( pkg, toolbar );
 		m_tv.push_back( toolbar );

--- a/src/rad/phppanel/phppanel.cpp
+++ b/src/rad/phppanel/phppanel.cpp
@@ -64,7 +64,7 @@ wxPanel( parent, id )
 	AppData()->AddHandler( this->GetEventHandler() );
 	wxBoxSizer *top_sizer = new wxBoxSizer( wxVERTICAL );
 
-	m_phpPanel = new CodeEditor( this, -1 );
+	m_phpPanel = new CodeEditor( this, wxID_ANY);
 	InitStyledTextCtrl( m_phpPanel->GetTextCtrl() );
 
 	top_sizer->Add( m_phpPanel, 1, wxEXPAND, 0 );

--- a/src/rad/pythonpanel/pythonpanel.cpp
+++ b/src/rad/pythonpanel/pythonpanel.cpp
@@ -64,7 +64,7 @@ wxPanel( parent, id )
 	AppData()->AddHandler( this->GetEventHandler() );
 	wxBoxSizer *top_sizer = new wxBoxSizer( wxVERTICAL );
 
-	m_pythonPanel = new CodeEditor( this, -1 );
+	m_pythonPanel = new CodeEditor( this, wxID_ANY);
 	InitStyledTextCtrl( m_pythonPanel->GetTextCtrl() );
 
 	top_sizer->Add( m_pythonPanel, 1, wxEXPAND, 0 );

--- a/src/rad/title.cpp
+++ b/src/rad/title.cpp
@@ -25,11 +25,11 @@
 
 #include "title.h"
 
-Title::Title(wxWindow *parent,const wxString &title) : wxPanel(parent,-1)
+Title::Title(wxWindow *parent,const wxString &title) : wxPanel(parent, wxID_ANY)
 {
   wxBoxSizer* sizer = new wxBoxSizer( wxVERTICAL );
 
-  wxStaticText *text = new wxStaticText(this,-1,title);//,wxDefaultPosition,wxDefaultSize,wxSIMPLE_BORDER);
+  wxStaticText *text = new wxStaticText(this, wxID_ANY,title);//,wxDefaultPosition,wxDefaultSize,wxSIMPLE_BORDER);
   SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_ACTIVECAPTION ) );
   text->SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_ACTIVECAPTION ) );
   text->SetForegroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_CAPTIONTEXT ) );
@@ -45,7 +45,7 @@ wxWindow * Title::CreateTitle (wxWindow *inner, const wxString &title)
 {
   wxWindow *parent = inner->GetParent();
 
-  wxPanel *container = new wxPanel(parent, -1);
+  wxPanel *container = new wxPanel(parent, wxID_ANY);
   Title *titleWin = new Title(container,title);
   inner->Reparent(container);
 

--- a/src/rad/xrcpanel/xrcpanel.cpp
+++ b/src/rad/xrcpanel/xrcpanel.cpp
@@ -59,7 +59,7 @@ XrcPanel::XrcPanel( wxWindow *parent, int id )
 	AppData()->AddHandler( this->GetEventHandler() );
 	wxBoxSizer *top_sizer = new wxBoxSizer( wxVERTICAL );
 
-	m_xrcPanel = new CodeEditor( this, -1 );
+	m_xrcPanel = new CodeEditor( this, wxID_ANY);
 	InitStyledTextCtrl( m_xrcPanel->GetTextCtrl() );
 
 	top_sizer->Add( m_xrcPanel, 1, wxEXPAND, 0 );

--- a/src/rad/xrcpreview/xrcpreview.cpp
+++ b/src/rad/xrcpreview/xrcpreview.cpp
@@ -222,7 +222,7 @@ void XRCPreview::Show( PObjectBase form, const wxString& projectPath )
 	}
 	else if ( className == wxT( "Panel" ) )
 	{
-		wxDialog* dialog = new wxDialog( wxTheApp->GetTopWindow(), -1, wxT( "Dialog" ), wxDefaultPosition,
+		wxDialog* dialog = new wxDialog( wxTheApp->GetTopWindow(), wxID_ANY, wxT( "Dialog" ), wxDefaultPosition,
 		                 wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
 		// Prevent events from propagating up to wxFB's frame
 		dialog->SetExtraStyle( wxWS_EX_BLOCK_EVENTS );

--- a/src/utils/annoyingdialog.cpp
+++ b/src/utils/annoyingdialog.cpp
@@ -22,13 +22,13 @@
 #include <wx/stattext.h>
 
 BEGIN_EVENT_TABLE(AnnoyingDialog, wxDialog)
-    EVT_BUTTON(-1, AnnoyingDialog::OnButton)
+    EVT_BUTTON(wxID_ANY, AnnoyingDialog::OnButton)
 END_EVENT_TABLE()
 
 AnnoyingDialog::AnnoyingDialog(const wxString& caption, const wxString& message, const wxArtID icon,
                                dStyle style, int defaultReturn, bool /*separate*/,
                                const wxString& b1, const wxString& b2, const wxString& b3)
-        : wxDialog(NULL, -1, caption, wxDefaultPosition, wxDefaultSize, wxCAPTION),
+        : wxDialog(NULL, wxID_ANY, caption, wxDefaultPosition, wxDefaultSize, wxCAPTION),
         m_cb(0),
         m_dontAnnoy(false),
         m_defRet(defaultReturn)
@@ -48,18 +48,18 @@ AnnoyingDialog::AnnoyingDialog(const wxString& caption, const wxString& message,
 	auto outerSizer = std::make_unique<wxBoxSizer>(wxVERTICAL);
 
     wxFlexGridSizer *mainArea = new wxFlexGridSizer(2, 0, 0);
-    wxStaticBitmap *bitmap = new wxStaticBitmap(this, -1, wxArtProvider::GetBitmap(icon,  wxART_MESSAGE_BOX), wxDefaultPosition);
+    wxStaticBitmap *bitmap = new wxStaticBitmap(this, wxID_ANY, wxArtProvider::GetBitmap(icon,  wxART_MESSAGE_BOX), wxDefaultPosition);
     mainArea->Add(bitmap, 0, wxALL, 5);
 
-    wxStaticText *txt = new wxStaticText(this, -1, message, wxDefaultPosition, wxDefaultSize, 0);
+    wxStaticText *txt = new wxStaticText(this, wxID_ANY, message, wxDefaultPosition, wxDefaultSize, 0);
     mainArea->Add( txt, 0, wxALIGN_CENTER|wxALL, 5 );
 
     mainArea->Add( 1, 1, 0, wxGROW|wxALIGN_CENTER_VERTICAL|wxLEFT|wxRIGHT|wxTOP, 5 );
 
     int numButtons = 0;
-    int id1 = -1;
-    int id2 = -1;
-    int id3 = -1;
+    int id1 = wxID_ANY;
+    int id2 = wxID_ANY;
+    int id3 = wxID_ANY;
     wxString bTxt1;
     wxString bTxt2;
     wxString bTxt3;
@@ -145,7 +145,7 @@ AnnoyingDialog::AnnoyingDialog(const wxString& caption, const wxString& message,
     outerSizer->Add( mainArea, 0, wxALIGN_CENTER|wxALL, 5);
     outerSizer->Add( buttonSizer, 0, wxALIGN_CENTER);
 
-    m_cb = new wxCheckBox(this, -1, _("Don't annoy me again!"), wxDefaultPosition, wxDefaultSize, 0);
+    m_cb = new wxCheckBox(this, wxID_ANY, _("Don't annoy me again!"), wxDefaultPosition, wxDefaultSize, 0);
     outerSizer->Add(m_cb, 0, wxALIGN_LEFT|wxLEFT|wxRIGHT|wxBOTTOM, 5);
 
 	SetSizer(outerSizer.release());


### PR DESCRIPTION
All static #define'ed WindowIDs have been replaced with enum values and their values have been shifted into wxID_HIGHEST + x range. This is recommended by wxWidgets to prevent clashes with their own static WindowIDs. Additionally collisions between elements that might appear in the same "event-context" have been resolved by shifted the values apart.

For dynamic WindowIDs the deprecated method calls have been replaced with the new method that doesn't create values that can collide with the static WindowIDs. All literal appearances of -1 for a WindowID have been replaced with wxID_ANY.