### PR TITLE
Fix eventhandler

### DIFF
--- a/plugins/additional/additional.cpp
+++ b/plugins/additional/additional.cpp
@@ -834,6 +834,15 @@ public:
 		return grid;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxGrid);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxGrid"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -954,6 +963,15 @@ public:
 		return colourpicker;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxColourPickerCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxColourPickerCtrl"), obj->GetPropertyAsString(_("name")));
 		xrc.AddProperty(_("colour"),_("value"),XRC_TYPE_COLOUR);
@@ -999,6 +1017,15 @@ public:
 
 		picker->PushEventHandler( new ComponentEvtHandler( picker, GetManager() ) );
 		return picker;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxFontPickerCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -1048,6 +1075,15 @@ public:
 		return picker;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxFilePickerCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxFilePickerCtrl"), obj->GetPropertyAsString(_("name")));
 		xrc.AddProperty(_("value"),_("value"),XRC_TYPE_TEXT);
@@ -1092,6 +1128,15 @@ public:
 
 		picker->PushEventHandler( new ComponentEvtHandler( picker, GetManager() ) );
 		return picker;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxDirPickerCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -1197,6 +1242,15 @@ public:
 		return ctrl;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxGenericDirCtrl);
+		if (window)
+		{
+			window->GetTreeCtrl()->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxGenericDirCtrl"), obj->GetPropertyAsString(_("name")));
 		xrc.AddProperty(_("defaultfolder"),_("defaultfolder"),XRC_TYPE_TEXT);
@@ -1258,6 +1312,15 @@ public:
 		sc->PushEventHandler( new ComponentEvtHandler( sc, GetManager() ) );
 
 		return sc;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxSearchCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -1327,6 +1390,15 @@ public:
 		mc->PushEventHandler( new ComponentEvtHandler( mc, GetManager() ) );
 
 		return mc;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxMediaCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -1700,6 +1772,15 @@ public:
 
 		return m_code;
 	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxStyledTextCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
 };
 
 void ComponentEvtHandler::OnMarginClick( wxStyledTextEvent& event )
@@ -1980,6 +2061,15 @@ class RibbonBarComponent : public ComponentBase
 		return rb;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxRibbonBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	void OnCreated(wxObject* wxobject, wxWindow* /*wxparent*/) override {
 		wxRibbonBar* rb = wxDynamicCast( wxobject, wxRibbonBar );
 		if ( NULL == rb )
@@ -2046,6 +2136,17 @@ class RibbonPageComponent : public ComponentBase
 
 		return rbpage;
 	}
+
+	/*
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxRibbonPage);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	*/
 };
 
 class RibbonPanelComponent : public ComponentBase
@@ -2064,6 +2165,16 @@ class RibbonPanelComponent : public ComponentBase
 		return rbp;
 	}
 
+	/*
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxRibbonPanel);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	*/
 };
 
 class RibbonButtonBarComponent : public ComponentBase
@@ -2079,6 +2190,18 @@ class RibbonButtonBarComponent : public ComponentBase
 
 		return rbb;
 	}
+
+	/*
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxRibbonButtonBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	*/
+
 	void OnCreated(wxObject* wxobject, wxWindow* /*wxparent*/) override {
 		wxRibbonButtonBar* rb = wxDynamicCast( wxobject, wxRibbonButtonBar );
 		if ( NULL == rb )
@@ -2139,6 +2262,18 @@ class RibbonToolBarComponent : public ComponentBase
 
 		return rbb;
 	}
+
+	/*
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxRibbonToolBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	*/
+
 	void OnCreated(wxObject* wxobject, wxWindow* /*wxparent*/) override {
 		wxRibbonToolBar* rb = wxDynamicCast( wxobject, wxRibbonToolBar );
 		if ( NULL == rb )
@@ -2196,6 +2331,18 @@ class RibbonGalleryComponent : public ComponentBase
 
 		return ribbonGallery;
 	}
+
+	/*
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxRibbonGallery);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	*/
+
 	void OnCreated(wxObject* wxobject, wxWindow* /*wxparent*/) override {
 		wxRibbonGallery* rg = wxDynamicCast( wxobject, wxRibbonGallery );
 		if ( NULL == rg )

--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -393,6 +393,15 @@ public:
 		return tc;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxTextCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject *obj) override
 	{
 		ObjectToXrcFilter xrc(obj, _("wxTextCtrl"), obj->GetPropertyAsString(_("name")));
@@ -500,6 +509,15 @@ public:
 		return combo;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxComboBox);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject *obj) override
 	{
 		ObjectToXrcFilter xrc(obj, _("wxComboBox"), obj->GetPropertyAsString(_("name")));
@@ -546,6 +564,15 @@ public:
 		return bcombo;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxBitmapComboBox);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxBitmapComboBox"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -577,6 +604,15 @@ public:
 		res->PushEventHandler( new ComponentEvtHandler( res, GetManager() ) );
 
 		return res;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxCheckBox);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -876,6 +912,17 @@ public:
 		return sb;
 	}
 
+	#ifndef __WXMSW__
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxStatusBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	#endif
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxStatusBar"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -1050,6 +1097,15 @@ public:
 		tb->PushEventHandler( new ComponentEvtHandler( tb, GetManager() ) );
 
 		return tb;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxToolBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	void OnCreated(wxObject* wxobject, wxWindow* /*wxparent*/) override {
@@ -1452,6 +1508,15 @@ public:
 		return choice;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxChoice);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxChoice"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -1591,6 +1656,15 @@ public:
 		return ac;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxAnimationCtrl);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxAnimationCtrl"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -1621,6 +1695,15 @@ public:
 		ib->PushEventHandler( new ComponentEvtHandler( ib, GetManager() ) );
 
 		return ib;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxInfoBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject *obj) override

--- a/plugins/containers/containers.cpp
+++ b/plugins/containers/containers.cpp
@@ -246,6 +246,15 @@ public:
 		return collpane;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxCollapsiblePane);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc( obj, _("wxCollapsiblePane"), obj->GetPropertyAsString( _("name") ) );
 		xrc.AddWindowProperties();
@@ -310,6 +319,21 @@ class SplitterWindowComponent : public ComponentBase
 		splitter->Connect( wxEVT_IDLE, wxIdleEventHandler( wxCustomSplitterWindow::OnIdle ) );
 
 		return splitter;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		// The derived class doesn't implement wxWidgets RTTI so cast to its base class
+		auto* window = wxDynamicCast(obj, wxSplitterWindow);
+		if (window)
+		{
+			// Because of possible error conditions the handler might not have been pushed
+			auto* compHandler = dynamic_cast<ComponentEvtHandler*>(window->GetEventHandler());
+			if (compHandler)
+			{
+				window->PopEventHandler(true);
+			}
+		}
 	}
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
@@ -512,6 +536,15 @@ public:
 		return book;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxNotebook);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxNotebook"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -579,6 +612,15 @@ public:
 		return book;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxListbook);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+	
 // Small icon style not supported by GTK
 #ifndef  __WXGTK__
 	void OnCreated(wxObject* wxobject, wxWindow* wxparent) override {
@@ -658,6 +700,15 @@ public:
 		return book;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxChoicebook);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxChoicebook"), obj->GetPropertyAsString(_("name")));
 		xrc.AddWindowProperties();
@@ -719,6 +770,15 @@ public:
 		book->PushEventHandler( new ComponentEvtHandler( book, GetManager() ) );
 
 		return book;
+	}
+
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxAuiNotebook);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
 	}
 
 #if wxVERSION_NUMBER >= 2905

--- a/plugins/forms/forms.cpp
+++ b/plugins/forms/forms.cpp
@@ -181,6 +181,15 @@ public:
 		return tb;
 	}
 
+	void Cleanup(wxObject* obj) override
+	{
+		auto* window = wxDynamicCast(obj, wxToolBar);
+		if (window)
+		{
+			window->PopEventHandler(true);
+		}
+	}
+
 	void OnCreated(wxObject* wxobject, wxWindow* /*wxparent*/) override {
 		wxToolBar* tb = wxDynamicCast( wxobject, wxToolBar );
 		if ( NULL == tb )

--- a/sdk/plugin_interface/plugin.h
+++ b/sdk/plugin_interface/plugin.h
@@ -211,17 +211,10 @@ public:
 		return m_manager->NewNoObject(); /* Even components which are not visible must be unique in the map */
 	}
 
-    void Cleanup( wxObject* obj )
-    {
-        wxWindow* window = dynamic_cast< wxWindow* >( obj );
-        if ( window != 0 )
-        {
-            if ( window->GetEventHandler() != window )
-            {
-                window->PopEventHandler( true );
-            }
-        }
-    }
+	void Cleanup(wxObject* /*obj*/)
+	{
+
+	}
 
 	void OnCreated( wxObject* /*wxobject*/, wxWindow* /*wxparent*/ )
 	{

--- a/sdk/plugin_interface/plugin.h
+++ b/sdk/plugin_interface/plugin.h
@@ -62,7 +62,7 @@ class ComponentLibrary : public IComponentLibrary
   SynMap m_synMap;
 
  public:
-  virtual ~ComponentLibrary()
+  ~ComponentLibrary() override
   {
 	std::vector< AComponent >::reverse_iterator component;
 	for ( component = m_components.rbegin(); component != m_components.rend(); ++component )
@@ -71,7 +71,7 @@ class ComponentLibrary : public IComponentLibrary
 	}
   }
 
-  void RegisterComponent( const wxString& text, IComponent* c )
+  void RegisterComponent(const wxString& text, IComponent* c) override
   {
     AComponent comp;
     comp.component = c;
@@ -80,7 +80,7 @@ class ComponentLibrary : public IComponentLibrary
     m_components.push_back(comp);
   }
 
-  void RegisterMacro(const wxString &text, const int value)
+  void RegisterMacro(const wxString& text, const int value) override
   {
     AMacro macro;
     macro.name = text;
@@ -89,7 +89,7 @@ class ComponentLibrary : public IComponentLibrary
     m_macros.push_back(macro);
   }
 
-  void RegisterMacroSynonymous(const wxString &syn, const wxString &name)
+  void RegisterMacroSynonymous(const wxString& syn, const wxString& name) override
   {
     /*ASynonymous asyn;
     asyn.name = name;
@@ -99,14 +99,14 @@ class ComponentLibrary : public IComponentLibrary
     m_synMap.insert(SynMap::value_type(syn, name));
   }
 
-  IComponent* GetComponent(unsigned int idx)
+  IComponent* GetComponent(unsigned int idx) override
   {
     if (idx < m_components.size())
       return m_components[idx].component;
     return NULL;
   }
 
-  wxString GetComponentName(unsigned int idx)
+  wxString GetComponentName(unsigned int idx) override
   {
     if (idx < m_components.size())
       return m_components[idx].name;
@@ -114,7 +114,7 @@ class ComponentLibrary : public IComponentLibrary
     return wxString();
   }
 
-  wxString GetMacroName(unsigned int idx)
+  wxString GetMacroName(unsigned int idx) override
   {
     if (idx < m_macros.size())
       return m_macros[idx].name;
@@ -122,7 +122,7 @@ class ComponentLibrary : public IComponentLibrary
     return wxString();
   }
 
-  int GetMacroValue(unsigned int idx)
+  int GetMacroValue(unsigned int idx) override
   {
     if (idx < m_macros.size())
       return m_macros[idx].value;
@@ -130,7 +130,7 @@ class ComponentLibrary : public IComponentLibrary
     return 0;
   }
 
-  /*wxString GetMacroSynonymous(unsigned int idx)
+  /*wxString GetMacroSynonymous(unsigned int idx) override
   {
     if (idx < m_synonymous.size())
       return m_synonymous[idx].syn;
@@ -138,7 +138,7 @@ class ComponentLibrary : public IComponentLibrary
     return wxString();
   }
 
-  wxString GetSynonymousName(unsigned int idx)
+  wxString GetSynonymousName(unsigned int idx) override
   {
     if (idx < m_synonymous.size())
       return m_synonymous[idx].name;
@@ -146,7 +146,7 @@ class ComponentLibrary : public IComponentLibrary
     return wxString();
   }*/
 
-  bool FindSynonymous(const wxString& syn, wxString& trans)
+  bool FindSynonymous(const wxString& syn, wxString& trans) override
   {
     bool found = false;
     SynMap::iterator it = m_synMap.find(syn);
@@ -159,17 +159,17 @@ class ComponentLibrary : public IComponentLibrary
     return found;
   }
 
-  unsigned int GetMacroCount()
+  unsigned int GetMacroCount() override
   {
     return (unsigned int)m_macros.size();
   }
 
-  unsigned int GetComponentCount()
+  unsigned int GetComponentCount() override
   {
     return (unsigned int)m_components.size();
   }
 
-  /*unsigned int GetSynonymousCount()
+  /*unsigned int GetSynonymousCount() override
   {
     return m_synonymous.size();
   }*/
@@ -206,37 +206,37 @@ public:
 		return m_manager;
 	}
 
-	wxObject* Create( IObject* /*obj*/, wxObject* /*parent*/ )
+	wxObject* Create(IObject* /*obj*/, wxObject* /*parent*/) override
 	{
 		return m_manager->NewNoObject(); /* Even components which are not visible must be unique in the map */
 	}
 
-	void Cleanup(wxObject* /*obj*/)
+	void Cleanup(wxObject* /*obj*/) override
 	{
 
 	}
 
-	void OnCreated( wxObject* /*wxobject*/, wxWindow* /*wxparent*/ )
+	void OnCreated(wxObject* /*wxobject*/, wxWindow* /*wxparent*/) override
 	{
 
 	}
 
-	void OnSelected( wxObject* /*wxobject*/ )
+	void OnSelected(wxObject* /*wxobject*/) override
 	{
 
 	}
 
-	ticpp::Element* ExportToXrc(IObject* /*obj*/)
-	{
-		return NULL;
-	}
-
-	ticpp::Element* ImportFromXrc(ticpp::Element* /*xrcObj*/)
+	ticpp::Element* ExportToXrc(IObject* /*obj*/) override
 	{
 		return NULL;
 	}
 
-	int GetComponentType()
+	ticpp::Element* ImportFromXrc(ticpp::Element* /*xrcObj*/) override
+	{
+		return NULL;
+	}
+
+	int GetComponentType() override
 	{
 		return m_type;
 	}


### PR DESCRIPTION
Fix assertions because of lost event handlers

The smart trick of the Component base class to pop the event handler if it doesn't match the object does not work because certain wxWidgets elements push event handlers themselves on child objects so this condition cannot be used to determine if the Component itself has pushed one. Remove the cleanup code from the base class and implement it in the derived class instead, this one knows for sure if it has pushed an event handler or not.

NOTE: This introduces an API break, plugins are now required to clean up their pushed event handlers, the base class doesn't do it anymore.