### PR TITLE
Improve highlight

### DIFF
--- a/src/rad/designer/visualeditor.cpp
+++ b/src/rad/designer/visualeditor.cpp
@@ -744,7 +744,7 @@ void VisualEditor::Generate( PObjectBase obj, wxWindow* wxparent, wxObject* pare
 			SetupWindow( obj, createdWindow );
 
 			// Push event handler in order to respond to Paint and Mouse events
-			createdWindow->PushEventHandler( new VObjEvtHandler( createdWindow, obj ) );
+			createdWindow->PushEventHandler(new VObjEvtHandler(m_back, createdWindow, obj));
 			break;
 
 		case COMPONENT_TYPE_SIZER:
@@ -1303,7 +1303,7 @@ wxInnerFrame(parent, id, pos, size, style)
 	m_actPanel = NULL;
 	SetBackgroundColour( wxSystemSettings::GetColour( wxSYS_COLOUR_BTNFACE ) );
 
-	GetFrameContentPanel()->PushEventHandler(new HighlightPaintHandler(GetFrameContentPanel()));
+	GetFrameContentPanel()->PushEventHandler(new HighlightPaintHandler(this, GetFrameContentPanel()));
 }
 
 DesignerWindow::~DesignerWindow()
@@ -1375,8 +1375,13 @@ void DesignerWindow::HighlightSelection( wxDC& dc )
 		}
 	}
 
-	wxSize size;
 	PObjectBase object = m_selObj.lock();
+	if (!(object && m_actPanel))
+	{
+		return;
+	}
+
+	wxSize size;
 	if ( m_selSizer )
 	{
 		wxScrolledWindow* scrolwin = wxDynamicCast(m_selSizer->GetContainingWindow (), wxScrolledWindow);
@@ -1612,20 +1617,19 @@ BEGIN_EVENT_TABLE(DesignerWindow::HighlightPaintHandler,wxEvtHandler)
 END_EVENT_TABLE()
 
 
-DesignerWindow::HighlightPaintHandler::HighlightPaintHandler(wxWindow *win)
+DesignerWindow::HighlightPaintHandler::HighlightPaintHandler(DesignerWindow* designer, wxWindow *win)
 {
+	m_designer = designer;
   m_window = win;
 }
 
 void DesignerWindow::HighlightPaintHandler::OnPaint(wxPaintEvent &event)
 {
-	wxWindow *aux = m_window;
-	while (!aux->IsKindOf(CLASSINFO(DesignerWindow))) aux = aux->GetParent();
-	DesignerWindow *dsgnWin = (DesignerWindow*) aux;
-	if (dsgnWin->GetActivePanel() == m_window)
+	wxPaintDC dc(m_window);
+
+	if (m_designer->GetActivePanel() == m_window)
 	{
-		wxPaintDC dc(m_window);
-		dsgnWin->HighlightSelection(dc);
+		m_designer->HighlightSelection(dc);
 	}
 
 	event.Skip();

--- a/src/rad/designer/visualeditor.h
+++ b/src/rad/designer/visualeditor.h
@@ -54,9 +54,10 @@ class DesignerWindow : public wxInnerFrame
       DECLARE_EVENT_TABLE()
 
       wxWindow *m_window;
+		DesignerWindow* m_designer;
 
      public:
-       HighlightPaintHandler(wxWindow *win);
+		HighlightPaintHandler(DesignerWindow* designer, wxWindow *win);
        void OnPaint(wxPaintEvent &event);
    };
 

--- a/src/rad/designer/visualeditor.h
+++ b/src/rad/designer/visualeditor.h
@@ -42,6 +42,7 @@ class DesignerWindow : public wxInnerFrame
    wxObject *m_selItem;
    WPObjectBase m_selObj;
    wxWindow *m_actPanel;
+	bool m_highlightOnIdle;
 
    void DrawRectangle(wxDC& dc, const wxPoint& point, const wxSize& size, PObjectBase object);
 
@@ -80,8 +81,9 @@ class DesignerWindow : public wxInnerFrame
    wxWindow* GetActivePanel() { return m_actPanel; }
    static wxMenu* GetMenuFromObject(PObjectBase menu);
    void SetFrameWidgets(PObjectBase menubar, wxWindow *toolbar, wxWindow* statusbar, wxWindow *auipanel);
-   void HighlightSelection(wxDC& dc);
+	void HighlightSelection(wxDC& dc, bool highlightOnIdle = false);
    void OnPaint(wxPaintEvent &event);
+   void OnIdle(wxIdleEvent& event);
 };
 
 class wxFBEvent;

--- a/src/rad/designer/visualobj.cpp
+++ b/src/rad/designer/visualobj.cpp
@@ -123,7 +123,7 @@ void VObjEvtHandler::OnPaint(wxPaintEvent &event)
 
 	if (m_designer->GetActivePanel() == m_window)
 	{
-		m_designer->HighlightSelection(dc);
+		m_designer->HighlightSelection(dc, true);
 	}
 
 	event.Skip();

--- a/src/rad/designer/visualobj.cpp
+++ b/src/rad/designer/visualobj.cpp
@@ -23,11 +23,12 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "visualeditor.h"
+#include "visualobj.h"
 
 #include "../../model/objectbase.h"
 #include "../../utils/typeconv.h"
 #include "../appdata.h"
+#include "visualeditor.h"
 
 using namespace TypeConv;
 
@@ -40,8 +41,8 @@ BEGIN_EVENT_TABLE( VObjEvtHandler, wxEvtHandler )
 	EVT_SET_CURSOR( VObjEvtHandler::OnSetCursor )
 END_EVENT_TABLE()
 
-VObjEvtHandler::VObjEvtHandler(wxWindow *win, PObjectBase obj)
-{
+VObjEvtHandler::VObjEvtHandler(DesignerWindow* designer, wxWindow* win, PObjectBase obj) {
+	m_designer = designer;
 	m_window = win;
 	m_object = obj;
 }
@@ -118,18 +119,13 @@ void VObjEvtHandler::OnRightClick(wxMouseEvent &event)
 
 void VObjEvtHandler::OnPaint(wxPaintEvent &event)
 {
-/*	PObjectBase wo = boost::shared_dynamic_cast<ObjectBase>(m_object.lock());
-	if (wo->IsContainer())
-	{ TODO: what this check is for? */
-		wxWindow *aux = m_window;
-		while (!aux->IsKindOf(CLASSINFO(DesignerWindow))) aux = aux->GetParent();
-		DesignerWindow *dsgnWin = (DesignerWindow*) aux;
-		if (dsgnWin->GetActivePanel() == m_window)
-		{
-			wxPaintDC dc(m_window);
-			dsgnWin->HighlightSelection(dc);
-		}
-/*	}*/
+	wxPaintDC dc(m_window);
+
+	if (m_designer->GetActivePanel() == m_window)
+	{
+		m_designer->HighlightSelection(dc);
+	}
+
 	event.Skip();
 }
 

--- a/src/rad/designer/visualobj.h
+++ b/src/rad/designer/visualobj.h
@@ -30,6 +30,8 @@
 
 #include <wx/wx.h>
 
+class DesignerWindow;
+
 /**
  * Processes events from visual objects.
  */
@@ -38,14 +40,13 @@ class VObjEvtHandler : public wxEvtHandler
  private:
    WPObjectBase m_object;
    wxWindow *m_window;
-
-   VObjEvtHandler() {};
+	DesignerWindow* m_designer;
 
  protected:
   DECLARE_EVENT_TABLE()
 
  public:
-   VObjEvtHandler(wxWindow *win, PObjectBase obj);
+	VObjEvtHandler(DesignerWindow* designer, wxWindow* win, PObjectBase obj);
    void OnLeftClick(wxMouseEvent &event);
    void OnRightClick(wxMouseEvent &event);
    void OnPaint(wxPaintEvent &event);


### PR DESCRIPTION
This improves the drawing of the selection highlights slightly and fixes a possible nullpointer crash.

It adds another interesting feature that was originally planned to fix the disappearing sizer highlight around a wxStaticBoxSizer but has some side effects in the current state. In most situations it currently reenables the highlights inside a wxStaticBoxSizer, but because the wrong parent is used to draw on, depending on the layout, the highlights can be in the wrong position. And because of the missing paint event handler, if the wxStaticBoxSizer is e.g. inside a wxScrolled, parts of the highlights will remain if it is scrolled.

These side effects will disappear with my upcoming PR that enables the currently disabled wxStaticBoxSizer fixes, but that one depends on #446 so i haven't pushed it yet.