### PR TITLE
Feature packageorder

### DIFF
--- a/src/model/database.cpp
+++ b/src/model/database.cpp
@@ -33,11 +33,9 @@
 #include "objectbase.h"
 
 #include <ticpp.h>
-#include <wx/config.h>
 #include <wx/dir.h>
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
-#include <wx/tokenzr.h>
 
 //#define DEBUG_PRINT(x) cout << x
 
@@ -711,30 +709,12 @@ void ObjectDatabase::LoadPlugins( PwxFBManager manager )
         moreDirectories = pluginsDir.GetNext( &pluginDirName );
     }
 
-    // Get previous plugin order
-	wxConfigBase* config = wxConfigBase::Get();
-	wxString pages = config->Read( wxT("/palette/pageOrder"), wxT("Common,Additional,Data,Containers,Menu/Toolbar,Layout,Forms,Ribbon") );
-
-	// Add packages to the vector in the correct order
-	wxStringTokenizer packageList( pages, wxT(",") );
-	while ( packageList.HasMoreTokens() )
+	// Add packages to final data structure
+	m_pkgs.reserve(packages.size());
+	for (auto& package : packages)
 	{
-		wxString packageName = packageList.GetNextToken();
-		PackageMap::iterator packageIt = packages.find( packageName );
-		if ( packages.end() == packageIt )
-		{
-			// Plugin missing - move on
-			continue;
-		}
-		m_pkgs.push_back( packageIt->second );
-		packages.erase( packageIt );
+		m_pkgs.push_back(package.second);
 	}
-
-    // If any packages remain in the map, they are new plugins and must still be added
-    for ( PackageMap::iterator packageIt = packages.begin(); packageIt != packages.end(); ++packageIt )
-    {
-    	m_pkgs.push_back( packageIt->second );
-    }
 }
 
 void ObjectDatabase::SetupPackage(const wxString& file,

--- a/src/rad/mainframe.cpp
+++ b/src/rad/mainframe.cpp
@@ -423,6 +423,7 @@ void MainFrame::RestorePosition( const wxString &name )
 void MainFrame::SavePosition( const wxString &name )
 {
 	m_objInsp->SavePosition();
+	m_palette->SavePosition();
 
 	wxConfigBase *config = wxConfigBase::Get();
 	bool isIconized = IsIconized();

--- a/src/rad/palette.cpp
+++ b/src/rad/palette.cpp
@@ -30,6 +30,8 @@
 #include "appdata.h"
 #include "auitabart.h"
 
+#include <wx/config.h>
+
 #ifdef __WXMAC__
 	#include <wx/tooltip.h>
 #endif
@@ -87,11 +89,28 @@ void wxFbPalette::PopulateToolbar( PObjectPackage pkg, wxAuiToolBar *toolbar )
 	}
 }
 
+void wxFbPalette::SavePosition()
+{
+	auto* config = wxConfigBase::Get();
+	wxString pageOrder;
+
+	for (size_t i = 0; i < m_notebook->GetPageCount(); ++i)
+	{
+		if (!pageOrder.empty())
+		{
+			pageOrder.append(wxT(","));
+		}
+		pageOrder.append(m_notebook->GetPageText(i));
+	}
+
+	config->Write(wxT("/palette/pageOrder"), pageOrder);
+}
+
 void wxFbPalette::Create()
 {
 	wxBoxSizer *top_sizer = new wxBoxSizer( wxVERTICAL );
 
-	m_notebook = new wxAuiNotebook( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_NB_TOP | wxAUI_NB_SCROLL_BUTTONS );
+	m_notebook = new wxAuiNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxAUI_NB_TOP | wxAUI_NB_SCROLL_BUTTONS | wxAUI_NB_TAB_MOVE);
 	m_notebook->SetArtProvider( new AuiTabArt() );
 
 	unsigned int pkg_count = AppData()->GetPackageCount();

--- a/src/rad/palette.h
+++ b/src/rad/palette.h
@@ -50,6 +50,8 @@ class wxFbPalette : public wxPanel
   wxFbPalette(wxWindow *parent,int id);
   ~wxFbPalette();
 
+	void SavePosition();
+
   /**
    * Crea la paleta, previamente se ha debido configurar el objeto
    * DataObservable.


### PR DESCRIPTION
This (re-)enables the ability to change the order of the package tabs (Common, Additional, ...) and store their order in the configuration. I think to remember this have been possible in the past, otherwise i can't explain why this settings is present on my machine, the current code does only read this setting but never write it.

This is quite useful if you use plugins and don't like them to be placed at the end in alphabetical order. This also cleans up the logic by moving this GUI related code fragment to the affected GUI component.