### PR TITLE
Modify python template for BitmapComboBox to comply with changes made in wxPython version 4

### DIFF
--- a/output/plugins/common/xml/common.pythoncode
+++ b/output/plugins/common/xml/common.pythoncode
@@ -117,7 +117,7 @@ Python code generation written by
 
   <templates class="wxBitmapComboBox">
 	<template name="construction">
-		self.$name = wx.combo.BitmapComboBox( #wxparent $name, $id, $value, $pos, $size, "", $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
+		self.$name = wx.adv.BitmapComboBox( #wxparent $name, $id, $value, $pos, $size, [], $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
 		#foreach $choices
 		@{ self.$name.Append( #pred.partition(":")[2], wx.Image.ConvertToBitmap(wx.Image(#pred.partition(":")[0]))); @}
 	</template>
@@ -125,7 +125,7 @@ Python code generation written by
 	<template name="evt_connect_OnCombobox">self.$name.Bind( wx.EVT_COMBOBOX, #handler )</template>
 	<template name="evt_connect_OnText">self.$name.Bind( wx.EVT_TEXT, #handler )</template>
 	<template name="evt_connect_OnTextEnter">self.$name.Bind( wx.EVT_TEXT_ENTER, #handler )</template>
-	<template name="include">import wx.combo</template>
+	<template name="include">import wx.adv</template>
   </templates>
 
   <templates class="wxListBox">


### PR DESCRIPTION
`BitmapComboBox` has been moved from module `combo` to  module `adv `in wxPython version 4.   (https://wxpython.org/Phoenix/docs/html/wx.adv.BitmapComboBox.html#wx.adv.BitmapComboBox). In fact wxPython 4 does not have a `combo` module`.

Also `BitmapComboBox` default `choices` argument should be an empty list `[]` and not an empty string `""`. 

Without both of these changes python code for user interfaces that include `BitmapComboBox` will produce an error when run using wxPython version 4. 