### PR TITLE
Perform subclass forward declaration even if header is empty

### DIFF
--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -1323,19 +1323,21 @@ void CppCodeGenerator::GenSubclassSets( PObjectBase obj, std::set< wxString >* s
 		}
 
 		// Now get the header
-		std::map< wxString, wxString >::iterator header;
-		header = children.find( wxT( "header" ) );
-
-		if ( children.end() == header )
+		wxString headerVal;
+		auto header = children.find(wxT("header"));
+		if (children.end() != header)
 		{
-			// No header, so do nothing
-			return;
+			headerVal = header->second;
 		}
 
-		wxString headerVal = header->second;
-		if ( headerVal.empty() )
+		if (headerVal.empty())
 		{
-			// No header, so do nothing
+			// No header, do a forward declare if requested, otherwise do nothing
+			if (forward_declare)
+			{
+				subclasses->insert(forwardDecl);
+			}
+
 			return;
 		}
 


### PR DESCRIPTION
Only now i discovered that commit 81a138b removes a bug/feature that some of my project files rely on. Before that commit a subclass forward declaration was always done, now it is only done if the subclass also defines a header.

My affected project files use e.g. a book control to which i add pages which are panels but i use the subclass feature to replace these with other classes. These other classes i define further down in the project file so i don't have (and can't if i don't want to depend on the filename of the project) to define a header for them. Because i generate C++ code and the subclasses get declared after the book control this doesn't compile.

This PR restores the behavior to generate forward declarations even with no defined header but only if forward declaration is enabled. This keeps the current feature to remove redundant forward declarations but adds the feature to enable them if they are required, what wxFormBuilder cannot detect by itself.