### PR TITLE
Lua code gen overhaul

### DIFF
--- a/output/plugins/common/xml/menutoolbar.luacode
+++ b/output/plugins/common/xml/menutoolbar.luacode
@@ -199,7 +199,7 @@ Lua code generation written by
   <templates class="wxAuiToolBar">
 	<template name="include"></template>
 	<template name="construction">
-		#utbl$name = wx.wxAuiToolBar( #utbl#wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wxDefaultValidator, $window_name @} )
+		#utbl$name = wxaui.wxAuiToolBar( #utbl#wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wxDefaultValidator, $window_name @} )
 
 		#ifnotnull $bitmapsize @{ #nl #utbl$name:SetToolBitmapSize( $bitmapsize ) @}
 

--- a/output/plugins/forms/xml/forms.luacode
+++ b/output/plugins/forms/xml/forms.luacode
@@ -131,7 +131,7 @@ Lua code generation writen by
 		</template>
 		<template name="after_addchild">
 		  #ifequal $aui_managed "1"
-			@{ #nl #utbl$name .m_mgr:Update() @} 
+			@{ #nl #utbl$name.m_mgr:Update() @} 
 			#ifnotnull $center
 			@{ #nl #utbl$name:Centre( $center ) @}
 		</template>

--- a/output/xml/default.luacode
+++ b/output/xml/default.luacode
@@ -4,11 +4,15 @@
     	<template name="lua_preamble">
 		</template>
 		<template name="include">
-			-- Load the wxLua module, does nothing if running from wxLua, wxLuaFreeze, or wxLuaEdit #nl
-			package.cpath = package.cpath..";./?.dll;./?.so;../lib/?.so;../lib/vc_dll/?.dll;../lib/bcc_dll/?.dll;../lib/mingw_dll/?.dll;" #nl
-			require("wx") #nl
+			-- Uncomment the next line to add paths for Lua to locate the wxLua native module #nl
+			-- package.cpath = package.cpath..";./?.dll;./?.so;../lib/?.so;../lib/vc_dll/?.dll;../lib/bcc_dll/?.dll;../lib/mingw_dll/?.dll;" #nl #nl
+			#nl
+			-- load the wxLua module, does nothing if running from wxLua, wxLuaFreeze, or wxLuaEdit #nl
+			#nl require("wx") #nl #nl
+			#nl local Object = function() return { __index = self }	end #nl #nl
 		</template>
     <template name="lua_epilogue">
+	  #nl #nl return ui
       #nl #nl --wx.wxGetApp():MainLoop()
     </template>
   </templates>
@@ -50,7 +54,7 @@
 			@{ 
 			#iftypeequal "widget || container || notebook || auinotebook || flatnotebook || listbook || choicebook || treelistctrl || splitter"
 			@{
-				#utbl#wxparent $name.m_mgr:AddPane( #utbl$name, wxaui.wxAuiPaneInfo()
+				#utbl#wxparent$name.m_mgr:AddPane( #utbl$name, wxaui.wxAuiPaneInfo()
 				#ifnotnull $aui_name @{:Name( $aui_name )@}:$docking()
 				#ifnotnull $caption @{:Caption( $caption )@}
 				#ifequal $caption_visible "0" @{:CaptionVisible( $caption_visible )@}

--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -1264,7 +1264,7 @@ void LuaCodeGenerator::GenConstructor(PObjectBase class_obj, const EventVector& 
 
 	wxString self("self.");
 	GenEvents( class_obj, events, strClassName );
-	m_source->WriteLn("return " + controlName);
+	m_source->WriteLn("return self." + controlName);
 	m_source->Unindent();
 	m_source->WriteLn("end");
 }

--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -1362,8 +1362,8 @@ void LuaCodeGenerator::GenConstruction(PObjectBase obj, bool is_widget, wxString
 				else
 					parentPostfix = wxEmptyString;
 
-				_template = wxT( " self.#parent$name" ) + parentPostfix + wxT( ":SetSizer( .self$name ) #nl" )
-					    wxT( "self.#parent$name" ) + parentPostfix + wxT( ":Layout()" )
+				_template = wxT( " self.#parent$name" ) + parentPostfix + wxT( ":SetSizer( self.$name ) #nl" )
+					    wxT( " self.#parent$name" ) + parentPostfix + wxT( ":Layout()" )
 					    wxT( "#ifnull #parent $size" )
 					    wxT( "@{ #nl self.$name:Fit( self.#parent $name" ) + parentPostfix + wxT( " ) @}" );
 


### PR DESCRIPTION
This is a big change to how Lua code gen works.

- There is no more global table, it produces a module.
- It allows instantiating when the user wants to, not on first parse
- It has a callback system for events where empty functions are called, which can be overridden later without touching the autogenerated code.

Usage:

    local ui = require("gui")

    ui.MainFrame:create()
    ui.MainFrame.MainFrame:Show()

    -- or

    local ui = require("gui")

    local main_frame = ui.MainFrame:create()
    main_frame:Show

All children are still accessible through the form entries in the table.

Let me know what you think, about anything, or if any bugs are found. I also enabled auiToolBar now that it's implemented in wxLua.
