### PR TITLE
Feature growables

### DIFF
--- a/output/plugins/layout/xml/layout.xml
+++ b/output/plugins/layout/xml/layout.xml
@@ -114,8 +114,8 @@ Written by
   <objectinfo class="flexgridsizerbase" icon="flex_grid_sizer.xpm" type="interface">
     <property name="vgap" type="uint" help="The vertical gap (in pixels) between the cells in the sizer.">0</property>
     <property name="hgap" type="uint" help="The horizontal gap (in pixels) between cells in the sizer.">0</property>
-    <property name="growablerows" type="uintlist" help="Comma separated list of row indices (starting from zero) that should be grown if there is extra space available to the sizer."/>
-    <property name="growablecols" type="uintlist" help="Comma separated list of column indices (starting from zero) that should be grown if there is extra space available to the sizer."/>
+    <property name="growablerows" type="uintpairlist" help="Comma separated list of row indices (starting from zero, optional proportion appended after a colon) that should be grown if there is extra space available to the sizer."/>
+    <property name="growablecols" type="uintpairlist" help="Comma separated list of column indices (starting from zero, optional proportion appended after a colon) that should be grown if there is extra space available to the sizer."/>
 	<property name="flexible_direction" type="option" help="Since wxWidgets 2.5.0, wxFlexGridSizer can size items equally in one direction but unequally ('flexibly') in the other" >
 	  <option name="wxVERTICAL"  	help="Rows are flexibly sized." />
 	  <option name="wxHORIZONTAL"  	help="Columns are flexibly sized." />

--- a/plugins/layout/layout.cpp
+++ b/plugins/layout/layout.cpp
@@ -302,17 +302,14 @@ class FlexGridSizerBase : public ComponentBase
 public:
 	void AddProperties( IObject* obj, wxFlexGridSizer* sizer )
 	{
-		wxArrayInt gcols, grows;
-		gcols = obj->GetPropertyAsArrayInt(_("growablecols"));
-		grows = obj->GetPropertyAsArrayInt(_("growablerows"));
-
-		unsigned int i;
-		for (i=0; i < gcols.GetCount() ; i++)
-			sizer->AddGrowableCol(gcols[i]);
-
-		for (i=0; i < grows.GetCount() ; i++)
-			sizer->AddGrowableRow(grows[i]);
-
+		for (const auto& col : obj->GetPropertyAsVectorIntPair(_("growablecols")))
+		{
+			sizer->AddGrowableCol(col.first, col.second);
+		}
+		for (const auto& row : obj->GetPropertyAsVectorIntPair(_("growablerows")))
+		{
+			sizer->AddGrowableRow(row.first, row.second);
+		}
 		sizer->SetMinSize( obj->GetPropertyAsSize(_("minimum_size")) );
 		sizer->SetFlexibleDirection( obj->GetPropertyAsInteger(_("flexible_direction")) );
 		sizer->SetNonFlexibleGrowMode( (wxFlexSizerGrowMode )obj->GetPropertyAsInteger(_("non_flexible_grow_mode")) );

--- a/sdk/plugin_interface/component.h
+++ b/sdk/plugin_interface/component.h
@@ -26,6 +26,9 @@
 #pragma once
 
 
+#include <vector>
+#include <utility>
+
 #include "wx/wx.h"
 #include "fontcontainer.h"
 
@@ -72,6 +75,7 @@ class IObject
   virtual wxBitmap GetPropertyAsBitmap  (const wxString& pname) = 0;
   virtual wxArrayInt GetPropertyAsArrayInt(const wxString& pname) = 0;
   virtual wxArrayString GetPropertyAsArrayString(const wxString& pname) = 0;
+  virtual std::vector<std::pair<int, int>> GetPropertyAsVectorIntPair(const wxString& pname) = 0;
   virtual double GetPropertyAsFloat(const wxString& pname) = 0;
   virtual wxString GetChildFromParentProperty( const wxString& parentName, const wxString& childName ) = 0;
   virtual wxString GetClassName() = 0;

--- a/src/codegen/codegen.cpp
+++ b/src/codegen/codegen.cpp
@@ -486,7 +486,7 @@ bool TemplateParser::ParseForEach()
 		// The template will be generated nesting as many times as
 		// tokens were found in the property value.
 
-		if (property->GetType() == PT_INTLIST || property->GetType() == PT_UINTLIST)
+		if (property->GetType() == PT_INTLIST || property->GetType() == PT_UINTLIST || property->GetType() == PT_INTPAIRLIST || property->GetType() == PT_UINTPAIRLIST)
 		{
 			// For doing that we will use wxStringTokenizer class from wxWidgets
 			wxStringTokenizer tkz( propvalue, wxT(","));
@@ -497,6 +497,8 @@ bool TemplateParser::ParseForEach()
 				token = tkz.GetNextToken();
 				token.Trim(true);
 				token.Trim(false);
+				// Pair values get interpreted as adjacent parameters, all supported languages use comma as parameter separator
+				token.Replace(wxT(":"), wxT(", "));
 
 				// Parsing the internal template
 				{

--- a/src/model/database.cpp
+++ b/src/model/database.cpp
@@ -1480,6 +1480,8 @@ void ObjectDatabase::InitPropertyTypes()
 	PT( wxT("bitlist"),		PT_BITLIST		);
 	PT( wxT("intlist"),		PT_INTLIST		);
 	PT( wxT("uintlist"),	PT_UINTLIST		);
+	PT(wxT("intpairlist"), PT_INTPAIRLIST);
+	PT(wxT("uintpairlist"), PT_UINTPAIRLIST);
 	PT( wxT("option"),		PT_OPTION		);
 	PT( wxT("macro"),		PT_MACRO		);
 	PT( wxT("path"),		PT_PATH			);

--- a/src/model/objectbase.cpp
+++ b/src/model/objectbase.cpp
@@ -725,7 +725,7 @@ wxArrayInt ObjectBase::GetPropertyAsArrayInt(const wxString& pname)
 	PProperty property = GetProperty( pname );
 	if (property)
 	{
-		IntList il( property->GetValue(), property->GetType() == PT_UINTLIST );
+		IntList il(property->GetValue(), property->GetType() == PT_UINTLIST, (property->GetType() == PT_INTPAIRLIST || property->GetType() == PT_UINTPAIRLIST));
 		for (unsigned int i=0; i < il.GetSize() ; i++)
 			array.Add(il.GetValue(i));
 	}
@@ -740,6 +740,24 @@ wxArrayString ObjectBase::GetPropertyAsArrayString(const wxString& pname)
 		return property->GetValueAsArrayString();
 	else
 		return wxArrayString();
+}
+
+std::vector<std::pair<int, int>> ObjectBase::GetPropertyAsVectorIntPair(const wxString& pname)
+{
+	std::vector<std::pair<int, int>> result;
+	
+	auto property = GetProperty(pname);
+	if (property)
+	{
+		IntList il(property->GetValue(), property->GetType() == PT_UINTLIST, (property->GetType() == PT_INTPAIRLIST || property->GetType() == PT_UINTPAIRLIST));
+		result.reserve(il.GetSize());
+		for (unsigned int i = 0; i < il.GetSize(); ++i)
+		{
+			result.emplace_back(il.GetPair(i));
+		}
+	}
+
+	return result;
 }
 
 wxString ObjectBase::GetChildFromParentProperty( const wxString& parentName, const wxString& childName )

--- a/src/model/objectbase.h
+++ b/src/model/objectbase.h
@@ -530,6 +530,7 @@ public:
 
 	wxArrayInt GetPropertyAsArrayInt(const wxString& pname) override;
 	wxArrayString GetPropertyAsArrayString(const wxString& pname) override;
+	std::vector<std::pair<int, int>> GetPropertyAsVectorIntPair(const wxString& pname) override;
 	wxString GetChildFromParentProperty(const wxString& parentName,
 	                                    const wxString& childName) override;
 

--- a/src/model/types.cpp
+++ b/src/model/types.cpp
@@ -96,50 +96,84 @@ PObjectType ObjectType::GetChildType(unsigned int idx)
 
 ///////////////////////////////////////////////////////////////////////////////
 
-IntList::IntList(wxString value, bool absolute_value )
-	:
-	m_abs( absolute_value )
+IntList::IntList(bool absolute_value, bool pair_value)
+	: m_abs(absolute_value)
+	, m_pairs(pair_value)
+{
+}
+
+IntList::IntList(const wxString& value, bool absolute_value, bool pair_value)
+	: IntList(absolute_value, pair_value)
 {
 	SetList(value);
 }
 
+
 void IntList::Add(int value)
 {
-	m_ints.push_back( m_abs ? std::abs(value) : value );
+	Add(value, 0);
+}
+
+void IntList::Add(int first, int second)
+{
+	if (m_abs)
+	{
+		m_ints.emplace_back(std::abs(first), (m_pairs ? std::abs(second) : 0));
+	}
+	else
+	{
+		m_ints.emplace_back(first, (m_pairs ? second : 0));
+	}
 }
 
 void IntList::DeleteList()
 {
-	m_ints.erase(m_ints.begin(), m_ints.end());
+	m_ints.clear();
 }
 
-void IntList::SetList(wxString str)
+void IntList::SetList(const wxString& str)
 {
 	DeleteList();
+
 	wxStringTokenizer tkz(str, wxT(","));
+	m_ints.reserve(tkz.CountTokens());
 	while (tkz.HasMoreTokens())
 	{
-		long value;
-		wxString token;
-		token = tkz.GetNextToken();
-		token.Trim(true);
-		token.Trim(false);
+		wxString secondToken;
+		wxString firstToken = tkz.GetNextToken().BeforeFirst(wxT(':'), &secondToken);
+		firstToken.Trim(true);
+		firstToken.Trim(false);
+		secondToken.Trim(true);
+		secondToken.Trim(false);
 
-		if (token.ToLong(&value))
-			Add((int)value);
+		long first;
+		long second = 0;
+		if (firstToken.ToLong(&first) && (!m_pairs || secondToken.empty() || secondToken.ToLong(&second)))
+		{
+			Add(static_cast<int>(first), static_cast<int>(second));
+		}
 	}
 }
 
-wxString IntList::ToString()
+
+wxString IntList::ToString(bool skip_zero_second)
 {
 	wxString result;
+	// Reserve some space to avoid many reallocations, assume one digit numbers
+	result.reserve(m_pairs ? m_ints.size() * 3 : m_ints.size() * 2);
 
-	if (m_ints.size() > 0)
+	for (const auto& entry : m_ints)
 	{
-		result = StringUtils::IntToStr(m_ints[0]);
+		if (!result.empty()) {
+			result.append(wxT(","));
+		}
 
-		for (unsigned int i=1; i< m_ints.size() ; i++)
-			result = result + wxT(",") + StringUtils::IntToStr(m_ints[i]);
+		result.append(StringUtils::IntToStr(entry.first));
+		if (m_pairs && !(skip_zero_second && entry.second == 0))
+		{
+			result.append(wxT(":"));
+			result.append(StringUtils::IntToStr(entry.second));
+		}
 	}
 
 	return result;

--- a/src/model/types.h
+++ b/src/model/types.h
@@ -27,6 +27,7 @@
 
 #include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <wx/wx.h>
 
@@ -138,6 +139,8 @@ typedef enum
 	PT_BITLIST,
 	PT_INTLIST,
 	PT_UINTLIST,
+	PT_INTPAIRLIST,
+	PT_UINTPAIRLIST,
 	PT_OPTION,
 	PT_MACRO,
 	PT_WXSTRING,
@@ -185,29 +188,31 @@ typedef enum
 class IntList
 {
 private:
-	typedef std::vector<int> IntVector;
-	IntVector m_ints;
+	std::vector<std::pair<int, int>> m_ints;
 	bool m_abs;
+	bool m_pairs;
 
 public:
-	IntList( bool absolute_value = false )
-		:
-		m_abs( absolute_value )
-	{
-	}
+	explicit IntList(bool absolute_value = false, bool pair_value = false);
+	explicit IntList(const wxString& value, bool absolute_value = false, bool pair_value = false);
 
-	IntList(wxString value, bool absolute_value = false );
-
-	unsigned int GetSize()
+	unsigned int GetSize() const
 	{
-		return (unsigned int)m_ints.size();
+		return static_cast<unsigned int>(m_ints.size());
 	}
-	int GetValue(unsigned int idx)
+	int GetValue(unsigned int idx) const
+	{
+		return m_ints[idx].first;
+	}
+	std::pair<int, int> GetPair(unsigned int idx) const
 	{
 		return m_ints[idx];
 	}
+
 	void Add(int value);
+	void Add(int first, int second);
 	void DeleteList();
-	void SetList(wxString str);
-	wxString ToString();
+	void SetList(const wxString& str);
+
+	wxString ToString(bool skip_zero_second = false);
 };

--- a/src/rad/inspector/objinspect.cpp
+++ b/src/rad/inspector/objinspect.cpp
@@ -291,9 +291,9 @@ wxPGProperty* ObjectInspector::GetProperty( PProperty prop )
 			}
 		}
 	}
-	else if (type == PT_INTLIST || type == PT_UINTLIST)
+	else if (type == PT_INTLIST || type == PT_UINTLIST || type == PT_INTPAIRLIST || type == PT_UINTPAIRLIST)
 	{
-		result = new wxStringProperty( name, wxPG_LABEL, IntList( prop->GetValueAsString(), type == PT_UINTLIST ).ToString() );
+		result = new wxStringProperty(name, wxPG_LABEL, IntList(prop->GetValueAsString(), type == PT_UINTLIST, (PT_INTPAIRLIST == type || PT_UINTPAIRLIST == type)).ToString(true));
 	}
 	else if (type == PT_OPTION || type == PT_EDIT_OPTION)
 	{
@@ -822,9 +822,11 @@ void ObjectInspector::OnPropertyGridChanged( wxPropertyGridEvent& event )
 			}
 			case PT_INTLIST:
 			case PT_UINTLIST:
+			case PT_INTPAIRLIST:
+			case PT_UINTPAIRLIST:
 			{
-				IntList il( event.GetPropertyValue(), PT_UINTLIST == prop->GetType() );
-				ModifyProperty( prop, il.ToString() );
+				IntList il(event.GetPropertyValue(), PT_UINTLIST == prop->GetType(), (PT_INTPAIRLIST == prop->GetType() || PT_UINTPAIRLIST == prop->GetType()));
+				ModifyProperty(prop, il.ToString(true));
 				break;
 			}
 			case PT_BITMAP:


### PR DESCRIPTION
While fixing the latest sizer related problem i discovered it's still not possible to specify the proportion for growable columns or rows. Turned out it was rather difficult to implement this. The basic problems are that there is no datatype in wxFB for this and limitations of the code template language.

This left me two choices:
1. Create new datatypes
2. Add the Proportions to a second parameter

I quickly dropped the second one because you cannot validate data across two parameters and the code templates needed to be changed (possible with a new language element) and the XRC code too.

So i ended up creating new datatypes that are based on the present intlist types. Because these types do not convert the data between the "stages" XRC<->storage<->display, the new ones don't either because i reuse the code path, so you have to use the XRC format for display.

I am not that happy about this, because these new datatypes sound quite generic but have quite a special property: drop the second parameter if it's zero. It just didn't look good with these appended `:0` (you can blame me for that, it was actually me who added this feature to the XRC system :smile:). Second issue is that the code generator turns each pair into one value separated with `,`, because this is a separator in every supported language this ends up as two values. This is necessary because the `#foreach` macro can process only one child value and is used when processing these lists. Well, at least that is somehow reflected by the name of the datatype.

I would merge it like this because i don't see another sensible way to implement this, but i want to check first if someone else has strong objections against this.
