### PR TITLE
Fix initial property in wxSpinCtrl

### DIFF
--- a/output/plugins/additional/xml/additional.xml
+++ b/output/plugins/additional/xml/additional.xml
@@ -278,7 +278,7 @@ Written by
     <property name="value" type="wxString"></property>
     <property name="min" type="int"     help="Minimal value.">0</property>
     <property name="max" type="int"     help="Maximal value.">10</property>
-    <property name="initial" type="uint" help="Initial value.">0</property>
+    <property name="initial" type="int" help="Initial value.">0</property>
     <property name="style" type="bitlist">
         <option name="wxSP_ARROW_KEYS"     help="The user can use arrow keys to change the value." />
         <option name="wxSP_WRAP"           help="The value wraps at the minimum and maximum." />


### PR DESCRIPTION
Changed uint to int for initial property in wxSpinCtrl as it could be negative value.