### PR TITLE
Fix compile error for wxStaticBoxSizer::OnUpdateUI

### DIFF
--- a/output/plugins/layout/xml/layout.cppcode
+++ b/output/plugins/layout/xml/layout.cppcode
@@ -64,7 +64,7 @@ Written by
 	</template>
     <template name="construction">$name = new wxStaticBoxSizer( new wxStaticBox( #wxparent $name, $id, $label ), $orient ); #nl</template>
 	<template name="evt_entry_OnUpdateUI">EVT_UPDATE_UI( $id, #handler )</template>
-	<template name="evt_connect_OnUpdateUI">this->Connect( $name->GetId(), wxEVT_UPDATE_UI, #handler );</template>
+	<template name="evt_connect_OnUpdateUI">$name->GetStaticBox()->Connect( wxEVT_UPDATE_UI, #handler, NULL, this );</template>
   </templates>
 
   <templates class="wxGridSizer">


### PR DESCRIPTION
Closes:  #478 

Sizer itself hasn't an id and can't been bound to event, so need to use inner StaticBox instead. 