### PR TITLE
Bug with subclass in components in python

### DIFF
--- a/output/plugins/additional/xml/additional.pythoncode
+++ b/output/plugins/additional/xml/additional.pythoncode
@@ -238,7 +238,7 @@ Python code generation written by
 
   <templates class="wxMediaCtrl">
     <template name="construction">
-		self.$name = wx.media.MediaCtrl( #wxparent $name, $id, wx.EmptyString, $pos, $size)
+		self.$name = #class( #wxparent $name, $id, wx.EmptyString, $pos, $size)
 		#ifnotnull $file
 		@{ #nl self.$name.Load( $file ) @}
 		#ifnotnull $playback_rate
@@ -269,7 +269,7 @@ Python code generation written by
 
 	<templates class="wxStyledTextCtrl">
 		<template name="construction">
-			self.$name = wx.stc.StyledTextCtrl(#wxparent $name, $id,  $pos, $size, $window_style)
+			self.$name = #class(#wxparent $name, $id,  $pos, $size, $window_style)
 			#nl self.$name.SetUseTabs  ( $use_tabs )
 			#nl self.$name.SetTabWidth ( $tab_width )
 			#nl self.$name.SetIndent   ( $tab_width )

--- a/output/plugins/additional/xml/data.pythoncode
+++ b/output/plugins/additional/xml/data.pythoncode
@@ -38,7 +38,7 @@ Python code generation written by
 	<template name="declaration">#class* $name;</template>
 	<template name="include">import wx.dataview</template>
 	<template name="construction">
-		self.$name = wx.dataview.DataViewCtrl( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} )
+		self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} )
 	</template>
 	<template name="evt_connect_OnDataViewCtrlSelectionChanged">self.$name.Bind( wx.dataview.EVT_DATAVIEW_SELECTION_CHANGED, #handler, id = $id )</template>
 	<template name="evt_connect_OnDataViewCtrlItemActivated">self.$name.Bind( wx.dataview.EVT_DATAVIEW_ITEM_ACTIVATED, #handler, id = $id )</template>
@@ -64,7 +64,7 @@ Python code generation written by
 	<template name="declaration">#class* $name;</template>
 	<template name="include">import wx.dataview</template>
 	<template name="construction">
-		self.$name = wx.dataview.DataViewTreeCtrl( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} ) 
+		self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} ) 
 	</template>
 	<template name="evt_connect_OnDataViewTreeCtrlSelectionChanged">self.$name.Bind( wx.dataview.EVT_DATAVIEW_SELECTION_CHANGED, #handler, id = $id )</template>
 	<template name="evt_connect_OnDataViewTreeCtrlItemActivated">self.$name.Bind( wx.dataview.EVT_DATAVIEW_ITEM_ACTIVATED, #handler, id = $id )</template>
@@ -90,7 +90,7 @@ Python code generation written by
 	<template name="declaration">#class* $name;</template>
 	<template name="include">import wx.dataview</template>
 	<template name="construction">
-		self.$name = wx.dataview.DataViewListCtrl( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} )
+		self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} )
 	</template>
 	<template name="evt_connect_OnDataViewListCtrlSelectionChanged">self.$name.Bind( wx.dataview.EVT_DATAVIEW_SELECTION_CHANGED, #handler, id = $id )</template>
 	<template name="evt_connect_OnDataViewListCtrlItemActivated">self.$name.Bind( wx.dataview.EVT_DATAVIEW_ITEM_ACTIVATED, #handler, id = $id )</template>
@@ -132,7 +132,7 @@ Python code generation written by
 	<template name="declaration">#class* $name;</template>
 	<template name="include">import wx.dataview</template>
 	<template name="construction">
-        self.$name = wx.dataview.TreeListCtrl( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
+        self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
     </template>
 	<template name="evt_connect_OnTreelistSelectionChanged">self.$name.Bind( wx.dataview.EVT_TREELIST_SELECTION_CHANGED, #handler )</template>
 	<template name="evt_connect_OnTreelistItemExpanding">self.$name.Bind( wx.dataview.EVT_TREELIST_ITEM_EXPANDING, #handler )</template>

--- a/output/plugins/additional/xml/ribbon.pythoncode
+++ b/output/plugins/additional/xml/ribbon.pythoncode
@@ -28,7 +28,7 @@ Python code generation writen by
   	<templates class="wxRibbonBar">
 		<template name="include">import wx.lib.agw.ribbon as rb</template>
 		<template name="construction">
-			self.$name = rb.RibbonBar( self , $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
+			self.$name = #class( self , $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
 		</template>
 		<template name="after_addchild">
 			self.$name.Realize()
@@ -55,7 +55,7 @@ Python code generation writen by
 
 	<templates class="wxRibbonPage">
 		<template name="construction">
-			self.$name = rb.RibbonPage( self.#parent $name,  $id, $label , $bitmap ,  0 )
+			self.$name = #class( self.#parent $name,  $id, $label , $bitmap ,  0 )
 		</template>
 		<template name="settings">
 			#ifequal $select "1"
@@ -65,14 +65,14 @@ Python code generation writen by
 
 	<templates class="wxRibbonPanel">
 		<template name="construction">
-			self.$name = rb.RibbonPanel( self.#parent $name,  $id, $label , $bitmap , $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
+			self.$name = #class( self.#parent $name,  $id, $label , $bitmap , $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
 		</template>
 		<template name="evt_connect_OnRibbonPanelExtbuttonActivated">@# event EVT_COMMAND_RIBBONPANEL_EXTBUTTON_ACTIVATED isn't currently supported by wxPython</template>
 	</templates>
  
 	<templates class="wxRibbonButtonBar">
 		<template name="construction">
-			self.$name = rb.RibbonButtonBar( self.#parent $name,  $id, $pos, $size, 0)
+			self.$name = #class( self.#parent $name,  $id, $pos, $size, 0)
 		</template>
 	</templates>
 
@@ -142,7 +142,7 @@ Python code generation writen by
 
 	<templates class="wxRibbonGallery">
 		<template name="construction">
-			self.$name = rb.RibbonGallery( self.#parent $name,  $id, $pos, $size, 0)
+			self.$name = #class( self.#parent $name,  $id, $pos, $size, 0)
 		</template>
 		<template name="generated_event_handlers"></template>
 		<template name="evt_connect_OnRibbonGallerySelected">self.Bind( rb.EVT_RIBBONGALLERY_SELECTED, #handler, id = $id )</template>

--- a/output/plugins/common/xml/common.pythoncode
+++ b/output/plugins/common/xml/common.pythoncode
@@ -117,7 +117,7 @@ Python code generation written by
 
   <templates class="wxBitmapComboBox">
 	<template name="construction">
-		self.$name = wx.adv.BitmapComboBox( #wxparent $name, $id, $value, $pos, $size, [], $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
+		self.$name = #class( #wxparent $name, $id, $value, $pos, $size, [], $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wx.DefaultValidator, $window_name @} )
 		#foreach $choices
 		@{ self.$name.Append( #pred.partition(":")[2], wx.Image.ConvertToBitmap(wx.Image(#pred.partition(":")[0]))); @}
 	</template>

--- a/output/plugins/common/xml/menutoolbar.pythoncode
+++ b/output/plugins/common/xml/menutoolbar.pythoncode
@@ -89,7 +89,7 @@ Python code generation writen by
   </templates>
 
   <templates class="submenu">
-	<template name="construction">self.$name = wx.Menu()</template>
+	<template name="construction">self.$name = #class()</template>
 	<template name="after_addchild">self.#parent $name.AppendSubMenu( self.$name, $label )</template>
   </templates>
 
@@ -205,7 +205,7 @@ Python code generation writen by
   <templates class="wxAuiToolBar">
 	<template name="include">import wx.aui</template>
 	<template name="construction">
-		self.$name = wx.aui.AuiToolBar( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wxDefaultValidator, $window_name @} )
+		self.$name = #class( #wxparent $name, $id, $pos, $size, $style #ifnotnull $window_style @{ |$window_style @} #ifnotnull $window_name @{, wxDefaultValidator, $window_name @} )
 
 		#ifnotnull $bitmapsize @{ #nl self.$name.SetToolBitmapSize( $bitmapsize ) @}
 


### PR DESCRIPTION
Problem with subclasses in some components in python.

I am using the latest version of the repository in windows:

When the subclass is configured in some components this is not reflected in the generated .py. as seen in the image.
For example to inherit the TreeListCtrl component of SubCLass_Name:
![imagen](https://user-images.githubusercontent.com/51421291/66950292-5e379500-f058-11e9-9156-b582c3982da6.png)

In other components it is done correctly: 

![imagen](https://user-images.githubusercontent.com/51421291/66950344-790a0980-f058-11e9-86c5-16cad90fcc08.png)

I have reviewed the xml, to correctly generate those components by replacing static assignments:

Original:
![imagen](https://user-images.githubusercontent.com/51421291/66950362-82937180-f058-11e9-943b-196611a1fab8.png)

Modified:

![imagen](https://user-images.githubusercontent.com/51421291/66950386-8b844300-f058-11e9-83b5-189dd501bba5.png)

They work right 

![imagen](https://user-images.githubusercontent.com/51421291/66950405-93dc7e00-f058-11e9-925d-9c1a03f0de66.png)

Thanks

Sorry my english is very bad.
