### PR TITLE
Stores wxObject pointer in a void* instead of a long.

### DIFF
--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -23,6 +23,8 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include  <unordered_map>
+
 #include <plugin.h>
 #include <ticpp.h>
 #include <xrcconv.h>
@@ -100,6 +102,15 @@ public:
 		m_manager = manager;
 	}
 
+	void SetPtrData(int index, void* ptr)
+	{
+		m_aObjects[index] = ptr;
+	}
+	void* GetPtrData(int index)
+	{
+		return m_aObjects[index];
+	}
+
 protected:
 	IManager* m_manager;
 
@@ -109,6 +120,9 @@ protected:
 	void OnTool( wxCommandEvent& event );
 
 	DECLARE_EVENT_TABLE()
+
+private:
+	std::unordered_map<int, void*> m_aObjects;
 };
 
 BEGIN_EVENT_TABLE( AuiToolBar, wxAuiToolBar )
@@ -1261,7 +1275,7 @@ void AuiToolBar::OnDropDownMenu( wxAuiToolBarEvent& event )
 
 		if ( item && item->HasDropDown() )
 		{
-			wxObject* wxobject = (wxObject*) item->GetUserData();
+			wxObject* wxobject = (wxObject*) GetPtrData(item->GetUserData());
 
 			if ( NULL != wxobject )
 			{
@@ -1298,11 +1312,15 @@ void AuiToolBar::OnTool( wxCommandEvent& event )
 		return;
 	}
 
-	wxObject* wxobject = (wxObject*) tb->FindTool( event.GetId() )->GetUserData();
-
-	if ( NULL != wxobject )
+	wxAuiToolBarItem* item = tb->FindTool(event.GetId());
+	if (item)
 	{
-		m_manager->SelectObject( wxobject );
+		wxObject* wxobject = (wxObject*) GetPtrData(item->GetUserData());
+
+		if (NULL != wxobject)
+		{
+			m_manager->SelectObject(wxobject);
+		}
 	}
 }
 
@@ -1354,7 +1372,9 @@ public:
 								child
 							);
 				wxAuiToolBarItem* itm = tb->FindToolByIndex( i );
-				itm->SetUserData( (long) child );
+				wxASSERT(itm);
+				itm->SetUserData(i);
+				tb->SetPtrData(i, child);
 				if ( childObj->GetPropertyAsInteger(_("context_menu") ) == 1 && !itm->HasDropDown() )
 					tb->SetToolDropDown( itm->GetId(), true );
 				else if ( childObj->GetPropertyAsInteger(_("context_menu") ) == 0 && itm->HasDropDown() )

--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -102,11 +102,11 @@ public:
 		m_manager = manager;
 	}
 
-	void SetPtrData(int index, void* ptr)
+	void SetObject(int index, wxObject* pObject)
 	{
-		m_aObjects[index] = ptr;
+		m_aObjects[index] = pObject;
 	}
-	void* GetPtrData(int index)
+	wxObject* GetObject(int index)
 	{
 		return m_aObjects[index];
 	}
@@ -122,7 +122,7 @@ protected:
 	DECLARE_EVENT_TABLE()
 
 private:
-	std::unordered_map<int, void*> m_aObjects;
+	std::unordered_map<int, wxObject*> m_aObjects;
 };
 
 BEGIN_EVENT_TABLE( AuiToolBar, wxAuiToolBar )
@@ -1275,9 +1275,9 @@ void AuiToolBar::OnDropDownMenu( wxAuiToolBarEvent& event )
 
 		if ( item && item->HasDropDown() )
 		{
-			wxObject* wxobject = (wxObject*) GetPtrData(item->GetUserData());
+			wxObject* wxobject = GetObject(item->GetUserData());
 
-			if ( NULL != wxobject )
+			if (wxobject)
 			{
 				m_manager->SelectObject( wxobject );
 			}
@@ -1315,9 +1315,9 @@ void AuiToolBar::OnTool( wxCommandEvent& event )
 	wxAuiToolBarItem* item = tb->FindTool(event.GetId());
 	if (item)
 	{
-		wxObject* wxobject = (wxObject*) GetPtrData(item->GetUserData());
+		wxObject* wxobject = GetObject(item->GetUserData());
 
-		if (NULL != wxobject)
+		if (wxobject)
 		{
 			m_manager->SelectObject(wxobject);
 		}
@@ -1374,7 +1374,7 @@ public:
 				wxAuiToolBarItem* itm = tb->FindToolByIndex( i );
 				wxASSERT(itm);
 				itm->SetUserData(i);
-				tb->SetPtrData(i, child);
+				tb->SetObject(i, child);
 				if ( childObj->GetPropertyAsInteger(_("context_menu") ) == 1 && !itm->HasDropDown() )
 					tb->SetToolDropDown( itm->GetId(), true );
 				else if ( childObj->GetPropertyAsInteger(_("context_menu") ) == 0 && itm->HasDropDown() )


### PR DESCRIPTION
Fixes # 562

The only significant issue preventing building **wxFormBuilder** and all plugins as a 64-bit target is issue #562 which refers to storing a pointer into a long.

On my fork I am now able to build and run a 64-bit version of **wxFormBuilder** and all plugin dlls. It does require an additional change to **ImportComponentLibrary** to load the correct version of the dll, however that's going to be dependent on build script changes, so I'm not including that change in this PR. In addition, just because it builds and runs, doesn't mean it's stable, so I want to spend a lot more time working with the 64-bit version before suggesting adding it as an optional build platform.

Note that I did not wrap the changes in bit-depth conditionals. While the change isn't strictly necessary for 32-bit builds, I don't think it will have any impact on performance. Not using conditionals in this case makes for easier to read code, and of course allows anyone else to build a 64-bit version.
