### PR TITLE
Enables/Disables Save button based on modified state of project file.

### DIFF
--- a/src/rad/mainframe.cpp
+++ b/src/rad/mainframe.cpp
@@ -965,8 +965,13 @@ void MainFrame::UpdateFrame()
 	GetStatusBar()->SetStatusText( filename, STATUS_FIELD_PATH );
 
 	// Enable/Disable toolbar and menu entries
-	wxMenu* menuEdit = GetMenuBar()->GetMenu( GetMenuBar()->FindMenu( wxT( "Edit" ) ) );
 	wxToolBar* toolbar = GetToolBar();
+
+	wxMenu* menuFile = GetMenuBar()->GetMenu(GetMenuBar()->FindMenu(_("File")));
+	menuFile->Enable(ID_SAVE_PRJ, AppData()->IsModified());
+	toolbar->EnableTool(ID_SAVE_PRJ, AppData()->IsModified());
+
+	wxMenu* menuEdit = GetMenuBar()->GetMenu( GetMenuBar()->FindMenu( wxT( "Edit" ) ) );
 
 	bool redo = AppData()->CanRedo();
 	menuEdit->Enable( ID_REDO, redo );


### PR DESCRIPTION
## Description

This PR enables/disables the Save menu item on the File menu, as well as the Save button on the toolbar based on whether the current project has been modified. It's added to the UpdateFrame() function that handles all the other enable/disable of UI elements.

### Notes

I'm so used to looking at the Save button to confirm that my current file has been saved, that when I first used **wxFB** I clicked the button multiple times wondering why my project wasn't being saved. Since **wxFB** already does a bunch of enabling/disabling it seemed to make sense to add the code that would bring this in line with common practice (at least on Windows -- I don't know if it's common on OS/X or Unix).