### PR TITLE
Changes UI interaction with user when loading an old project file

### DIFF
--- a/src/rad/appdata.cpp
+++ b/src/rad/appdata.cpp
@@ -1326,11 +1326,16 @@ bool ApplicationData::LoadProject( const wxString &file, bool justGenerate )
 			}
 
 			wxMessageBox(
-			    _("This project is using an older file format. It will be converted in memory while loading it.\n\n"
-			      "Caution! If you save the project, it will be overwritten with the newer file format."),
+			    _("This project file is using an older file format, it will be updated during loading.\n\n"
+			      "WARNING: Saving the project will update the format of the project file on disk!"),
 			    _("Older file format"));
 
-			if (!ConvertProject(doc, file, fbpVerMajor, fbpVerMinor))
+			if (ConvertProject(doc, file, fbpVerMajor, fbpVerMinor))
+			{
+				// Document has changed -- reacquire the root node
+				root = doc.FirstChildElement();
+			}
+			else
 			{
 				wxLogError(wxT("Unable to convert project"));
 				return false;
@@ -1377,7 +1382,6 @@ bool ApplicationData::ConvertProject(ticpp::Document& doc, const wxString& path,
 {
 	try
 	{
-		ticpp::Document doc;
 		XMLUtils::LoadXMLFile( doc, false, path );
 
 		ticpp::Element* root = doc.FirstChildElement();

--- a/src/rad/appdata.cpp
+++ b/src/rad/appdata.cpp
@@ -49,6 +49,7 @@
 #include <wx/fs_arc.h>
 #include <wx/fs_filter.h>
 #include <wx/fs_mem.h>
+#include <wx/richmsgdlg.h>
 #include <wx/tokenzr.h>
 
 using namespace TypeConv;
@@ -1323,24 +1324,15 @@ bool ApplicationData::LoadProject( const wxString &file, bool justGenerate )
 				wxLogError( wxT( "This project file is out of date.  Update your .fbp before using --generate" ) );
 				return false;
 			}
-			if ( wxYES == wxMessageBox( wxT( "This project file is not of the current version.\n" )
-			                            wxT( "Would you to attempt automatic conversion?\n\n" )
-			                            wxT( "NOTE: This will modify your project file on disk!" ), _( "Old Version" ), wxYES_NO ) )
-			{
-				// we make a backup of the project
-				::wxCopyFile( file, file + wxT( ".bak" ) );
 
-				if ( !ConvertProject( file, fbpVerMajor, fbpVerMinor ) )
-				{
-					wxLogError( wxT( "Unable to convert project" ) );
-					return false;
-				}
+			wxMessageBox(
+			    _("This project is using an older file format. It will be converted in memory while loading it.\n\n"
+			      "Caution! If you save the project, it will be overwritten with the newer file format."),
+			    _("Older file format"));
 
-				XMLUtils::LoadXMLFile( doc, false, file );
-				root = doc.FirstChildElement();
-			}
-			else
+			if (!ConvertProject(doc, file, fbpVerMajor, fbpVerMinor))
 			{
+				wxLogError(wxT("Unable to convert project"));
 				return false;
 			}
 		}
@@ -1363,7 +1355,8 @@ bool ApplicationData::LoadProject( const wxString &file, bool justGenerate )
 			PObjectBase old_proj = m_project;
 			m_project = proj;
 			m_selObj = m_project;
-			m_modFlag = false;
+			// Set the modification to true if the project was older and has been converted
+			m_modFlag = older;
 			m_cmdProc.Reset();
 			m_projectFile = file;
 			SetProjectPath( ::wxPathOnly( file ) );
@@ -1380,7 +1373,7 @@ bool ApplicationData::LoadProject( const wxString &file, bool justGenerate )
 	return true;
 }
 
-bool ApplicationData::ConvertProject( const wxString& path, int fileMajor, int fileMinor )
+bool ApplicationData::ConvertProject(ticpp::Document& doc, const wxString& path, int fileMajor, int fileMinor)
 {
 	try
 	{
@@ -1388,7 +1381,6 @@ bool ApplicationData::ConvertProject( const wxString& path, int fileMajor, int f
 		XMLUtils::LoadXMLFile( doc, false, path );
 
 		ticpp::Element* root = doc.FirstChildElement();
-
 		if ( root->Value() == std::string( "object" ) )
 		{
 			ConvertProjectProperties( root, path, fileMajor, fileMinor );
@@ -1428,8 +1420,6 @@ bool ApplicationData::ConvertProject( const wxString& path, int fileMajor, int f
 			fileVersion->SetAttribute( "major", m_fbpVerMajor );
 			fileVersion->SetAttribute( "minor", m_fbpVerMinor );
 		}
-
-		doc.SaveFile();
 	}
 	catch ( ticpp::Exception& ex )
 	{

--- a/src/rad/appdata.h
+++ b/src/rad/appdata.h
@@ -31,6 +31,7 @@
 
 namespace ticpp
 {
+class Document;
 
 class Node;
 
@@ -274,7 +275,8 @@ class ApplicationData
 		@param fileMinor The minor revision of the file
 		@return true if successful, false otherwise
 		*/
-		bool ConvertProject( const wxString& path, int fileMajor, int fileMinor );
+
+		bool ConvertProject(ticpp::Document& doc, const wxString& path, int fileMajor, int fileMinor);
 
 		/**
 		Recursive function used to convert the object tree in the project file to the latest version.


### PR DESCRIPTION
Fixes #567 

## Description

This changes the message that is displayed when **wxFB** opens an older project file. It states the name of the backup file, and indicates that the new project file will be saved. It then confirms that the backup file was created, and if not, gives the user a choice of retry, skip, cancel.

To see the dialog that is displayed if the copy fails (this assumes that wxfbTest.fbp is still an old version):

- cd to wxfbTest
- copy wxfbTest.fbp to wxfbTest.fbp.bak
- write-protect wxfbTest.fbp.bak
- open wxfbTest.fbp in **wxFB**

Note: This adds a debug-only log message that displays old/new version -- it's there purely for debugging convenience.