### PR TITLE
Change handling of non-UTF8 XML files

### DIFF
--- a/src/utils/stringutils.cpp
+++ b/src/utils/stringutils.cpp
@@ -179,22 +179,15 @@ namespace XMLUtils
 		else
 		{
 			// Ask user to all wxFB to convert the file to UTF-8 and add the XML declaration
-			wxString msg = wxString::Format( _("This xml file has specified encoding %s. wxFormBuilder only works with UTF-8.\n"),
-							wxFontMapper::GetEncodingDescription( encoding ).c_str() );
-			msg 		+= _("Would you like wxFormBuilder to backup the file and convert it to UTF-8\?\n\n");
-			msg			+= _("Path: ");
-			msg			+= path;
+			wxString msg = wxString::Format(_("This xml file has specified encoding: %s.\n\n"),
+			      wxFontMapper::GetEncodingDescription(encoding).c_str());
+			msg += _("wxFormBuilder may not correctly display strings unless the encoding is UTF-8.\n\n");
+			msg += _("Do you wish to continue?\n");
 			if ( wxNO == wxMessageBox( msg, _("Not UTF-8"), wxICON_QUESTION | wxYES_NO | wxYES_DEFAULT, wxTheApp->GetTopWindow() ) )
 			{
 				// User declined, give up
 				THROW_WXFBEX( _("Wrong Encoding for XML File: ") << path );
 			}
-
-			// User accepted, convert the file
-			ConvertAndChangeDeclaration( path, version, standalone, encoding );
-
-			// Reload
-			LoadXMLFile( doc, condenseWhiteSpace, path );
 			return;
 		}
 	}


### PR DESCRIPTION
Currently, when **wxFB** is asked to import an XRC file that uses an encoding other then `utf-8` it will ask the user for permission to backup the file and then save the original version with the encoding changed. However, it doesn't actually convert the strings in the file, it simply changes the encoding tag to `utf-8` and reloads the file. That means that not only will **wxFB** still not be able to correctly display non-ANSI characters, but by saving the file with the invalid encoding tag, the program that created it will also no longer be able to display strings correctly.

This PR changes the message displayed to the user to indicate strings may not be displayed correctly, and simply asks if the user wishes to continue or not. It removes the call to changing the encoding tag, and no longer saves and reloads the file.

Note that this is in the LoadXMLFileImp() function -- so it will affect any XML file loaded by **wxFB**. That should be fine -- if the user changed the encoding of a project file using an external XML editor, what they really need to do is fix the problem using that editor. **wxFB** does not have the ability to correctly convert the entire file to utf-8. It should not be saving a broken XML file that can no longer be fixed by any XML editor.