### PR TITLE
Add additional header symlinks for win32 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ git clone --recursive --depth=1 https://github.com/wxFormBuilder/wxFormBuilder
 cd wxFormBuilder
 cmd.exe /C "create_build_files4.bat --wx-root=/mingw32/bin --force-wx-config --disable-mediactrl"
 ln -s /mingw32/include/binutils/bfd.h /mingw32/include/bfd.h
+ln -s /mingw32/include/binutils/bfd_stdint.h /mingw32/include/bfd_stdint.h
+ln -s /mingw32/include/binutils/diagnostics.h /mingw32/include/diagnostics.h
 ln -s /mingw32/include/binutils/symcat.h /mingw32/include/symcat.h
 ln -s /mingw32/lib/binutils/libbfd.a /mingw32/lib/libbfd.a
 ln -s /mingw32/lib/binutils/libiberty.a /mingw32/lib/libiberty.a


### PR DESCRIPTION
win32 builds complain about missing headers for bfd_stdint.h and
diagnostics.h