### PR TITLE
Add cpp_preamble to inherited C++ code

### DIFF
--- a/output/xml/default.cppcode
+++ b/output/xml/default.cppcode
@@ -305,7 +305,13 @@
 			// Handlers for $basename events.
 		</template>
 		<template name="header_include">@#include &quot;$gen_file.h&quot;</template>
-		<template name="source_include">@#include &quot;$file.h&quot;</template>
+		<template name="source_include">
+			#ifnotnull $precompiled_header
+			@{
+				$precompiled_header #nl
+			@}
+			@#include &quot;$file.h&quot;
+		</template>
 		<template name="class_decl">
 			/** Implementing $basename */ #nl
 			class $name : public $basename

--- a/output/xml/default.xml
+++ b/output/xml/default.xml
@@ -227,6 +227,9 @@
     <property name="file" type="text"/>
     <property name="gen_file" type="text"/>
     <property name="type" type="text"/>
+    <category name="C++ Properties">
+      <property name="precompiled_header" type="text"/>
+    </category>
   </objectinfo>
 
   <objectinfo class="AUI" type="interface">

--- a/src/rad/appdata.cpp
+++ b/src/rad/appdata.cpp
@@ -2391,8 +2391,9 @@ void ApplicationData::GenerateInheritedClass( PObjectBase form, wxString classNa
 		PProperty fileProp = obj->GetProperty( wxT( "file" ) );
 		PProperty genfileProp = obj->GetProperty( wxT( "gen_file" ) );
 		PProperty typeProp = obj->GetProperty( wxT( "type" ) );
+		PProperty pchProp = obj->GetProperty(wxT("precompiled_header"));
 
-		if ( !( baseNameProp && nameProp && fileProp && typeProp && genfileProp ) )
+		if (!(baseNameProp && nameProp && fileProp && typeProp && genfileProp && pchProp))
 		{
 			wxLogWarning( wxT("Missing Property") );
 			return;
@@ -2425,6 +2426,12 @@ void ApplicationData::GenerateInheritedClass( PObjectBase form, wxString classNa
 		fileProp->SetValue( inherFile.GetName() );
 		genfileProp->SetValue( genFile.GetFullPath() );
 		typeProp->SetValue( form->GetClassName() );
+
+        auto property = project->GetProperty(wxT("precompiled_header"));
+        if (property)
+        {
+            pchProp->SetValue(property->GetValue());
+        }
 
 		// Determine if Microsoft BOM should be used
 		bool useMicrosoftBOM = false;

--- a/src/rad/appdata.cpp
+++ b/src/rad/appdata.cpp
@@ -2427,10 +2427,10 @@ void ApplicationData::GenerateInheritedClass( PObjectBase form, wxString classNa
 		genfileProp->SetValue( genFile.GetFullPath() );
 		typeProp->SetValue( form->GetClassName() );
 
-        auto property = project->GetProperty(wxT("precompiled_header"));
-        if (property)
+        auto pchValue = project->GetProperty(wxT("precompiled_header"));
+        if (pchValue)
         {
-            pchProp->SetValue(property->GetValue());
+            pchProp->SetValue(pchValue->GetValue());
         }
 
 		// Determine if Microsoft BOM should be used


### PR DESCRIPTION
It's unlikely that a user will want a precompiled header added to the generated C++ source file, and not want the same precompiled header added to the inherited C++ source file. This PR simply adds the same user-defined preamble to the inherited file(s) that is already added to the generated file(s).