### PR TITLE
Package names update in Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd ../../../output/
 Pre-requisites for Ubuntu:
 
 ```sh
-sudo apt install libwxgtk3.0-dev libwxgtk-media3.0-dev meson
+sudo apt install libwxgtk3.0-gtk3-dev libwxgtk-media3.0-gtk3-dev meson
 ```
 
 Pre-requisites for Arch Linux:


### PR DESCRIPTION
According to Ubuntu 20.04, these are the packages that are needed now, otherwise you get:
```
E: Package 'libwxgtk3.0-dev' has no installation candidate
E: Unable to locate package libwxgtk-media3.0-dev
E: Couldn't find any package by glob 'libwxgtk-media3.0-dev
```