### PR TITLE
Remove property label from wxMenuBar

### DIFF
--- a/output/plugins/common/xml/menutoolbar.xml
+++ b/output/plugins/common/xml/menutoolbar.xml
@@ -41,7 +41,6 @@ Written by
   <objectinfo class="wxMenuBar" icon="menubar.xpm" type="menubar" startgroup="1">
     <inherits class="wxWindow"/>
     <property name="name" type="text">m_menubar</property>
-    <property name="label" type="wxString_i18n">MyMenuBar</property>
     <property name="style" type="bitlist">
       <option name="wxMB_DOCKABLE" help="Allows the menu bar to be detached (wxGTK only)."/>
     </property>

--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -975,13 +975,11 @@ public:
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, _("wxMenuBar"), obj->GetPropertyAsString(_("name")));
-		xrc.AddProperty(_("label"),_("label"),XRC_TYPE_TEXT);
 		return xrc.GetXrcObject();
 	}
 
 	ticpp::Element* ImportFromXrc(ticpp::Element* xrcObj) override {
 		XrcToXfbFilter filter(xrcObj, _("wxMenuBar"));
-		filter.AddProperty(_("label"),_("label"),XRC_TYPE_TEXT);
 		return filter.GetXfbObject();
 	}
 };

--- a/plugins/forms/forms.cpp
+++ b/plugins/forms/forms.cpp
@@ -144,13 +144,11 @@ public:
 
 	ticpp::Element* ExportToXrc(IObject* obj) override {
 		ObjectToXrcFilter xrc(obj, wxT("wxMenuBar"), obj->GetPropertyAsString(wxT("name")));
-		xrc.AddProperty(wxT("label"),wxT("label"),XRC_TYPE_TEXT);
 		return xrc.GetXrcObject();
 	}
 
 	ticpp::Element* ImportFromXrc(ticpp::Element* xrcObj) override {
 		XrcToXfbFilter filter(xrcObj, wxT("MenuBar"));
-		filter.AddProperty(wxT("label"),wxT("label"),XRC_TYPE_TEXT);
 		return filter.GetXfbObject();
 	}
 };

--- a/src/rad/appdata.cpp
+++ b/src/rad/appdata.cpp
@@ -2213,6 +2213,19 @@ void ApplicationData::ConvertObject( ticpp::Element* parent, int fileMajor, int 
 	}
 
 	/* The file is now at least version 1.15 */
+	if (fileMajor < 1 || (fileMajor == 1 && fileMinor < 16))
+	{
+		static bool showRemovalWarnings = true;
+		if (objClass == "wxMenuBar")
+		{
+			RemoveProperties(parent, std::set<std::string>{"label"});
+			if (showRemovalWarnings)
+			{
+				wxLogMessage(_("Removed property label for class wxMenuBar because it is no longer used"));
+				showRemovalWarnings = false;
+			}
+		}
+	}
 }
 
 void ApplicationData::GetPropertiesToConvert( ticpp::Node* parent, const std::set< std::string >& names, std::set< ticpp::Element* >* properties )


### PR DESCRIPTION
Fixes: #610 

I don't know is there any special code that should be modified after removing property(for clarify warning or something), but I didn't find any so I just removed occurrences. 