### PR TITLE
wxGrid new feature plus bug fix in PT_EDIT_OPTION

### DIFF
--- a/output/plugins/additional/xml/data.cppcode
+++ b/output/plugins/additional/xml/data.cppcode
@@ -265,9 +265,12 @@ Written by
 			@}
 			#nl $name->EnableDragColMove( $drag_col_move );
 			#nl $name->EnableDragColSize( $drag_col_size );
-			#nl $name->SetColLabelSize( $col_label_size );
 			#foreach $col_label_values
 			@{ $name->SetColLabelValue( #npred, #pred ); @}
+			#ifnotnull $col_label_size
+			@{
+				#nl $name->SetColLabelSize( $col_label_size );
+			@}
 			#nl $name->SetColLabelAlignment( $col_label_horiz_alignment, $col_label_vert_alignment );
 			#nl
 			#nl // Rows
@@ -278,9 +281,12 @@ Written by
 				#nl $name->AutoSizeRows();
 			@}
 			#nl $name->EnableDragRowSize( $drag_row_size );
-			#nl $name->SetRowLabelSize( $row_label_size );
 			#foreach $row_label_values
 			@{ $name->SetRowLabelValue( #npred, #pred ); @}
+			#ifnotnull $row_label_size
+			@{
+				#nl $name->SetRowLabelSize( $row_label_size );
+			@}
 			#nl $name->SetRowLabelAlignment( $row_label_horiz_alignment, $row_label_vert_alignment );
 			#nl
 			#nl // Label Appearance

--- a/output/plugins/additional/xml/data.luacode
+++ b/output/plugins/additional/xml/data.luacode
@@ -169,9 +169,12 @@ Lua code generation written by
 				#nl #utbl$name:AutoSizeColumns()
 			@}
 			#nl #utbl$name:EnableDragColSize( $drag_col_size )
-			#nl #utbl$name:SetColLabelSize( $col_label_size )
 			#foreach $col_label_values
 			@{ #utbl$name:SetColLabelValue( #npred, #pred ) @}
+			#ifnotnull col_label_size
+			@{
+				#nl #utbl$name:SetColLabelSize( $col_label_size )
+			@}
 			#nl #utbl$name:SetColLabelAlignment( $col_label_horiz_alignment, $col_label_vert_alignment )
 			#nl
 			#nl @-- Rows
@@ -182,9 +185,12 @@ Lua code generation written by
 				#nl #utbl$name:AutoSizeRows()
 			@}
 			#nl #utbl$name:EnableDragRowSize( $drag_row_size )
-			#nl #utbl$name:SetRowLabelSize( $row_label_size )
 			#foreach $row_label_values
 			@{ #utbl$name:SetRowLabelValue( #npred, #pred ) @}
+			#ifnotnull $row_label_size
+			@{
+				#nl #utbl$name:SetRowLabelSize( $row_label_size )
+			@}
 			#nl #utbl$name:SetRowLabelAlignment( $row_label_horiz_alignment, $row_label_vert_alignment )
 			#nl
 			#nl @-- Label Appearance

--- a/output/plugins/additional/xml/data.phpcode
+++ b/output/plugins/additional/xml/data.phpcode
@@ -175,9 +175,12 @@ PHP code generation written by
 			@}
 			#nl @$this->$name->EnableDragColMove( $drag_col_move );
 			#nl @$this->$name->EnableDragColSize( $drag_col_size );
-			#nl @$this->$name->SetColLabelSize( $col_label_size );
 			#foreach $col_label_values
 			@{ @$this->$name->SetColLabelValue( #npred, #pred ); @}
+			#ifnotnull $col_label_size
+			@{
+				#nl @$this->$name->SetColLabelSize( $col_label_size );
+			@}
 			#nl @$this->$name->SetColLabelAlignment( $col_label_horiz_alignment, $col_label_vert_alignment );
 			#nl
 			#nl @# Rows
@@ -188,9 +191,12 @@ PHP code generation written by
 				#nl @$this->$name->AutoSizeRows();
 			@}
 			#nl @$this->$name->EnableDragRowSize( $drag_row_size );
-			#nl @$this->$name->SetRowLabelSize( $row_label_size );
 			#foreach $row_label_values
 			@{ @$this->$name->SetRowLabelValue( #npred, #pred ); @}
+			#ifnotnull $row_label_size
+			@{
+				#nl @$this->$name->SetRowLabelSize( $row_label_size );
+			@}
 			#nl @$this->$name->SetRowLabelAlignment( $row_label_horiz_alignment, $row_label_vert_alignment );
 			#nl
 			#nl @# Label Appearance

--- a/output/plugins/additional/xml/data.pythoncode
+++ b/output/plugins/additional/xml/data.pythoncode
@@ -181,9 +181,12 @@ Python code generation written by
 			@}
 			#nl self.$name.EnableDragColMove( $drag_col_move )
 			#nl self.$name.EnableDragColSize( $drag_col_size )
-			#nl self.$name.SetColLabelSize( $col_label_size )
 			#foreach $col_label_values
 			@{ self.$name.SetColLabelValue( #npred, #pred ) @}
+			#ifnotnull $col_label_size
+			@{
+				#nl self.$name.SetColLabelSize( $col_label_size )
+			@}
 			#nl self.$name.SetColLabelAlignment( $col_label_horiz_alignment, $col_label_vert_alignment )
 			#nl
 			#nl @# Rows
@@ -194,9 +197,12 @@ Python code generation written by
 				#nl self.$name.AutoSizeRows()
 			@}
 			#nl self.$name.EnableDragRowSize( $drag_row_size )
-			#nl self.$name.SetRowLabelSize( $row_label_size )
 			#foreach $row_label_values
 			@{ self.$name.SetRowLabelValue( #npred, #pred ) @}
+			#ifnotnull $row_label_size
+			@{
+				#nl self.$name.SetRowLabelSize( $row_label_size )
+			@}
 			#nl self.$name.SetRowLabelAlignment( $row_label_horiz_alignment, $row_label_vert_alignment )
 			#nl
 			#nl @# Label Appearance

--- a/output/plugins/additional/xml/data.xml
+++ b/output/plugins/additional/xml/data.xml
@@ -69,7 +69,9 @@ Written by
       <property name="autosize_cols" type="bool" help="Automatically sizes all columns to fit their contents. wxGrid sets up arrays to store individual row and column sizes when non-default sizes are used. The memory requirements for this could become prohibitive if your grid is very large.">0</property>
       <property name="drag_col_move" type="bool" help="Allow moving columns by dragging.">0</property>
       <property name="drag_col_size" type="bool" help="Allow sizing columns by dragging.">1</property>
-      <property name="col_label_size" type="uint" help="Height of column labels">30</property>
+      <property name="col_label_size" type="editoption" help="Height of column labels">
+        <option name="wxGRID_AUTOSIZE" help="If height equals to wxGRID_AUTOSIZE then height is calculated automatically so that no label is truncated. Note that this could be slow for a large table."/>
+      </property>
       <property name="col_label_values" type="stringlist" help="List of column labels."></property>
       <property name="col_label_horiz_alignment" type="option" help="Horizontal alignment of column label text.">
         <option name="wxALIGN_LEFT" help="Align labels left."/>
@@ -88,7 +90,9 @@ Written by
       <property name="row_sizes" type="uintlist" help="Comma separated list of row sizes. Note: wxGrid sets up arrays to store individual row and column sizes when non-default sizes are used. The memory requirements for this could become prohibitive if your grid is very large."/>
       <property name="autosize_rows" type="bool" help="Automatically sizes all rows to fit their contents. wxGrid sets up arrays to store individual row and column sizes when non-default sizes are used. The memory requirements for this could become prohibitive if your grid is very large.">0</property>
       <property name="drag_row_size" type="bool" help="Allow sizing rows by dragging.">1</property>
-      <property name="row_label_size" type="uint" help="Width of row labels">80</property>
+      <property name="row_label_size" type="editoption" help="Width of row labels">
+        <option name="wxGRID_AUTOSIZE" help="If height equals to wxGRID_AUTOSIZE then width is calculated automatically so that no label is truncated. Note that this could be slow for a large table."/>
+      </property>
       <property name="row_label_values" type="stringlist" help="List of row labels."></property>
       <property name="row_label_horiz_alignment" type="option" help="Horizontal alignment of row label text.">
         <option name="wxALIGN_LEFT" help="Align labels left."/>

--- a/plugins/additional/additional.cpp
+++ b/plugins/additional/additional.cpp
@@ -924,12 +924,16 @@ public:
 
 		// Label Properties
 		grid->SetColLabelAlignment( obj->GetPropertyAsInteger( _("col_label_horiz_alignment") ), obj->GetPropertyAsInteger( _("col_label_vert_alignment") ) );
-		grid->SetColLabelSize( obj->GetPropertyAsInteger( _("col_label_size") ) );
 
 		wxArrayString columnLabels = obj->GetPropertyAsArrayString( _("col_label_values") );
 		for ( int i = 0; i < (int)columnLabels.size() && i < grid->GetNumberCols(); ++i )
 		{
 			grid->SetColLabelValue( i, columnLabels[i] );
+		}
+
+		if ( !obj->IsNull( _("col_label_size") ) )
+		{
+			grid->SetColLabelSize( obj->GetPropertyAsInteger( _("col_label_size") ) );
 		}
 
 		wxArrayInt columnSizes = obj->GetPropertyAsArrayInt( _("column_sizes") );
@@ -939,12 +943,16 @@ public:
 		}
 
 		grid->SetRowLabelAlignment( obj->GetPropertyAsInteger( _("row_label_horiz_alignment") ), obj->GetPropertyAsInteger( _("row_label_vert_alignment") ) );
-		grid->SetRowLabelSize( obj->GetPropertyAsInteger( _("row_label_size") ) );
 
 		wxArrayString rowLabels = obj->GetPropertyAsArrayString( _("row_label_values") );
 		for ( int i = 0; i < (int)rowLabels.size() && i < grid->GetNumberRows(); ++i )
 		{
 			grid->SetRowLabelValue( i, rowLabels[i] );
+		}
+
+		if ( !obj->IsNull( _("row_label_size") ) )
+		{
+			grid->SetRowLabelSize( obj->GetPropertyAsInteger( _("row_label_size") ) );
 		}
 
 		wxArrayInt rowSizes = obj->GetPropertyAsArrayInt( _("row_sizes") );
@@ -2796,6 +2804,7 @@ MACRO(wxALIGN_CENTER)
 MACRO(wxALIGN_RIGHT)
 MACRO(wxALIGN_TOP)
 MACRO(wxALIGN_BOTTOM)
+MACRO(wxGRID_AUTOSIZE)
 
 // wxScrollBar
 MACRO(wxSB_HORIZONTAL)

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -1796,6 +1796,8 @@ void PythonTemplateParser::SetupModulePrefixes()
 	ADD_PREDEFINED_PREFIX( wxAUI_MGR_LIVE_RESIZE, wx.aui. );
 	ADD_PREDEFINED_PREFIX( wxAUI_MGR_DEFAULT, wx.aui. );
 
+	ADD_PREDEFINED_PREFIX( wxGRID_AUTOSIZE, wx.grid. );
+
 	ADD_PREDEFINED_PREFIX( wxAC_DEFAULT_STYLE, wx.adv. );
 	ADD_PREDEFINED_PREFIX( wxAC_NO_AUTORESIZE, wx.adv. );
 
@@ -1844,14 +1846,14 @@ void PythonTemplateParser::SetupModulePrefixes()
 	ADD_PREDEFINED_PREFIX( wxPG_TOOLBAR, wx.propgrid. );
 	ADD_PREDEFINED_PREFIX( wxPGMAN_DEFAULT_STYLE, wx.propgrid. );
 	ADD_PREDEFINED_PREFIX( wxPG_NO_INTERNAL_BORDER, wx.propgrid. );
-	
+
 	ADD_PREDEFINED_PREFIX( wxDATAVIEW_CELL_ACTIVATABLE, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDATAVIEW_CELL_INERT, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDATAVIEW_COL_HIDDEN, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDATAVIEW_COL_REORDERABLE, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDATAVIEW_COL_RESIZABLE, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDATAVIEW_COL_SORTABLE, wx.dataview. );
-	
+
 	ADD_PREDEFINED_PREFIX( wxDV_SINGLE, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDV_MULTIPLE, wx.dataview. );
 	ADD_PREDEFINED_PREFIX( wxDV_ROW_LINES, wx.dataview. );
@@ -1875,4 +1877,3 @@ void PythonTemplateParser::SetupModulePrefixes()
 
 	ADD_PREDEFINED_PREFIX( wxTP_DEFAULT, wx.adv. );
 }
-

--- a/src/utils/typeconv.cpp
+++ b/src/utils/typeconv.cpp
@@ -246,7 +246,10 @@ int TypeConv::GetMacroValue(const wxString &str)
 	int value = 0;
 
 	PMacroDictionary dic = MacroDictionary::GetInstance();
-	dic->SearchMacro( str, &value );
+	if (!dic->SearchMacro(str, &value))
+	{
+		value = StringToInt(str);
+	}
 
 	return value;
 }


### PR DESCRIPTION
This PR is for a new feature: To allow `col_label_size` and `row_label_size` in `wxGrid` control to take on their default values, as well as the option `wxGRID_AUTOSIZE`. This fixes issue #355 

To add this feature I converted both properties from "uint" to "editoption".

--------------------------

When I made this conversion I discovered a bug in how "editoption" (`PT_EDIT_OPTION`) was implemented: When the edit value is not one of the valid options, the result should be parsed from the string not 0 as it was. I fixed this bug in a separate, completely independent commit for clarity and to make the code review easier. 

To fix this bug in a modular way, I added a new method `bool    IsMacro(const wxString &str )` to `TypeConv`  that returns whether the current string value of a property corresponds to a registered macro or not.