### PR TITLE
Add support for EVT_LIST_ITEM_CHECKED and EVT_LIST_ITEM_UNCHECKED t…

### DIFF
--- a/output/plugins/common/xml/common.cppcode
+++ b/output/plugins/common/xml/common.cppcode
@@ -252,6 +252,10 @@ Written by
 		<template name="evt_connect_OnListColEndDrag">$name->Connect( wxEVT_COMMAND_LIST_COL_END_DRAG, #handler, NULL, this );</template>
 		<template name="evt_entry_OnListCacheHint">EVT_LIST_CACHE_HINT( $id, #handler )</template>
 		<template name="evt_connect_OnListCacheHint">$name->Connect( wxEVT_COMMAND_LIST_CACHE_HINT, #handler, NULL, this );</template>
+		<template name="evt_entry_OnListItemChecked">EVT_LIST_ITEM_CHECKED( $id, #handler )</template>
+		<template name="evt_connect_OnListItemChecked">$name->Connect( wxEVT_COMMAND_LIST_ITEM_CHECKED, #handler, NULL, this );</template>
+		<template name="evt_entry_OnListItemUnchecked">EVT_LIST_ITEM_UNCHECKED( $id, #handler )</template>
+		<template name="evt_connect_OnListItemUnchecked">$name->Connect( wxEVT_COMMAND_LIST_ITEM_UNCHECKED, #handler, NULL, this );</template>
 	</templates>
 
 	<templates class="wxChoice">

--- a/output/plugins/common/xml/common.luacode
+++ b/output/plugins/common/xml/common.luacode
@@ -197,6 +197,8 @@ Lua code generation written by
 		<template name="evt_connect_OnListColDragging">#utbl$name:Connect( wx.wxEVT_COMMAND_LIST_COL_DRAGGING, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 		<template name="evt_connect_OnListColEndDrag">#utbl$name:Connect( wx.wxEVT_COMMAND_LIST_COL_END_DRAG, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 		<template name="evt_connect_OnListCacheHint">#utbl$name:Connect( wx.wxEVT_COMMAND_LIST_CACHE_HINT, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+		<template name="evt_connect_OnListItemChecked">#utbl$name:Connect( wx.wxEVT_COMMAND_LIST_ITEM_CHECKED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
+		<template name="evt_connect_OnListItemUnchecked">#utbl$name:Connect( wx.wxEVT_COMMAND_LIST_ITEM_UNCHECKED, function(event)#nl --implements  #handler#nl #skip #nl end )</template>
 	</templates>
 
 	<templates class="wxChoice">

--- a/output/plugins/common/xml/common.phpcode
+++ b/output/plugins/common/xml/common.phpcode
@@ -193,6 +193,8 @@ PHP code generation written by
 		<template name="evt_connect_OnListColDragging">@$this->$name->Connect( wxEVT_COMMAND_LIST_COL_DRAGGING, #handler );</template>
 		<template name="evt_connect_OnListColEndDrag">@$this->$name->Connect( wxEVT_COMMAND_LIST_COL_END_DRAG, #handler );</template>
 		<template name="evt_connect_OnListCacheHint">@$this->$name->Connect( wxEVT_COMMAND_LIST_CACHE_HINT, #handler );</template>
+		<template name="evt_connect_OnListItemChecked">@$this->$name->Connect( wxEVT_COMMAND_LIST_ITEM_CHECKED, #handler );</template>
+		<template name="evt_connect_OnListItemUnchecked">@$this->$name->Connect( wxEVT_COMMAND_LIST_ITEM_UNCHECKED, #handler );</template>
 	</templates>
 
 	<templates class="wxChoice">

--- a/output/plugins/common/xml/common.pythoncode
+++ b/output/plugins/common/xml/common.pythoncode
@@ -193,6 +193,8 @@ Python code generation written by
 		<template name="evt_connect_OnListColDragging">self.$name.Bind( wx.EVT_LIST_COL_DRAGGING, #handler )</template>
 		<template name="evt_connect_OnListColEndDrag">self.$name.Bind( wx.EVT_LIST_COL_END_DRAG, #handler )</template>
 		<template name="evt_connect_OnListCacheHint">self.$name.Bind( wx.EVT_LIST_CACHE_HINT, #handler )</template>
+		<template name="evt_connect_OnListItemChecked">self.$name.Bind( wx.EVT_LIST_ITEM_CHECKED, #handler )</template>
+		<template name="evt_connect_OnListItemUnchecked">self.$name.Bind( wx.EVT_LIST_ITEM_UNCHECKED, #handler )</template>
 	</templates>
 
 	<templates class="wxChoice">

--- a/output/plugins/common/xml/common.xml
+++ b/output/plugins/common/xml/common.xml
@@ -245,6 +245,8 @@ Written by
     <event name="OnListColDragging" class="wxListEvent" help="The divider between columns is being dragged."/>
     <event name="OnListColEndDrag" class="wxListEvent" help="A column has been resized by the user."/>
     <event name="OnListCacheHint" class="wxListEvent" help="Prepare cache for a virtual list control."/>
+    <event name="OnListItemChecked" class="wxListEvent" help="The item has been checked."/>
+    <event name="OnListItemUnchecked" class="wxListEvent" help="The item has been unchecked."/>
   </objectinfo>
 
   <objectinfo class="wxCheckBox" icon="checkbox.xpm" type="widget">


### PR DESCRIPTION
This pull request is for a new feature: It adds support for `EVT_LIST_ITEM_CHECKED` and `EVT_LIST_ITEM_UNCHECKED` to `ListCtrl`.

Background:

This events were added to ListCtrl in 3.1 (https://docs.wxwidgets.org/trunk/classwx_list_ctrl.html) which was released in February 2016 (https://en.wikipedia.org/wiki/WxWidgets)