### PR TITLE
Add read_only support to StyledTextCtrl

### DIFF
--- a/output/plugins/additional/xml/additional.cppcode
+++ b/output/plugins/additional/xml/additional.cppcode
@@ -396,6 +396,7 @@ Written by
 			#nl $name->SetViewWhiteSpace( $view_whitespace );
 			#nl $name->SetMarginWidth( 2, 0 );
 			#nl $name->SetIndentationGuides( $indentation_guides );
+			#nl $name->SetReadOnly( $read_only );
 			#ifequal $folding "1"
 			@{
 				#nl $name->SetMarginType( 1, wxSTC_MARGIN_SYMBOL );

--- a/output/plugins/additional/xml/additional.pythoncode
+++ b/output/plugins/additional/xml/additional.pythoncode
@@ -283,6 +283,7 @@ Python code generation written by
 			#nl self.$name.SetViewWhiteSpace( $view_whitespace )
 			#nl self.$name.SetMarginWidth( 2, 0 )
 			#nl self.$name.SetIndentationGuides( $indentation_guides )
+			#nl self.$name.SetReadOnly( $read_only );
 			#ifequal $folding "1"
 			@{
 				#nl self.$name.SetMarginType  ( 1, wx.stc.STC_MARGIN_SYMBOL )

--- a/output/plugins/additional/xml/additional.xml
+++ b/output/plugins/additional/xml/additional.xml
@@ -80,6 +80,7 @@ Written by
     <property name="view_whitespace" type="bool" help="Show whitespace characters.">0</property>
     <property name="use_tabs" type="bool" help="Use tabs for indenting, instead of spaces.">1</property>
     <property name="tab_width" type="text" help="The number of spaces per tab character.">4</property>
+    <property name="read_only" type="bool" help="Set ReadOnly Mode. Disable editing.">0</property>
   </objectinfo>
 
   <objectinfo class="wxToggleButton" startgroup="1" icon="toggle_button.xpm" type="widget">


### PR DESCRIPTION
This pull request adds support for the `read_only` property of widget `StyledTextCtrl` to all generators that currently support the StyledTextCtrl widget (currently cpp and python).