### PR TITLE
Bug fix in python code generation for StyledTextCtrl and MediaCtrl

### DIFF
--- a/output/plugins/additional/xml/additional.pythoncode
+++ b/output/plugins/additional/xml/additional.pythoncode
@@ -242,7 +242,7 @@ Python code generation written by
 
 	<templates class="wxMediaCtrl">
 		<template name="construction">
-			self.$name = wx.media.MediaCtrl( #wxparent $name, $id, wx.EmptyString, $pos, $size)
+			self.$name = #class( #wxparent $name, $id, wx.EmptyString, $pos, $size)
 			#ifnotnull $file
 			@{ #nl self.$name.Load( $file ) @}
 			#ifnotnull $playback_rate
@@ -273,7 +273,7 @@ Python code generation written by
 
 	<templates class="wxStyledTextCtrl">
 		<template name="construction">
-			self.$name = wx.stc.StyledTextCtrl(#wxparent $name, $id,  $pos, $size, $window_style)
+			self.$name = #class( #wxparent $name, $id,  $pos, $size, $window_style)
 			#nl self.$name.SetUseTabs  ( $use_tabs )
 			#nl self.$name.SetTabWidth ( $tab_width )
 			#nl self.$name.SetIndent   ( $tab_width )

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -1729,6 +1729,7 @@ void PythonTemplateParser::SetupModulePrefixes()
 	// altered class names
 	ADD_PREDEFINED_PREFIX( wxCalendarCtrl, wx.adv. );
 	ADD_PREDEFINED_PREFIX( wxRichTextCtrl, wx.richtext. );
+	ADD_PREDEFINED_PREFIX( wxStyledTextCtrl, wx.stc. );
 	ADD_PREDEFINED_PREFIX( wxHtmlWindow, wx.html. );
 	ADD_PREDEFINED_PREFIX( wxAuiNotebook, wx.aui. );
 	ADD_PREDEFINED_PREFIX( wxGrid, wx.grid. );
@@ -1736,6 +1737,7 @@ void PythonTemplateParser::SetupModulePrefixes()
 	ADD_PREDEFINED_PREFIX( wxDatePickerCtrl, wx.adv. );
 	ADD_PREDEFINED_PREFIX( wxTimePickerCtrl, wx.adv. );
 	ADD_PREDEFINED_PREFIX( wxHyperlinkCtrl, wx.adv. );
+	ADD_PREDEFINED_PREFIX( wxMediaCtrl, wx.media. );
 
 	// altered macros
 	ADD_PREDEFINED_PREFIX( wxCAL_SHOW_HOLIDAYS, wx.adv. );


### PR DESCRIPTION
This pull requests fixes a bug in python code generation for StyledTextCtrl and MediaCtrl by which the widget's class name was hardcoded during construction which prevented subclassing.