### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = 1
+tab_width = 4
+trim_trailing_whitespace = 1


### PR DESCRIPTION
For those like me that uses it other than clang-format.
I noticed late that you are using tab for indentation? I can force push to change spaces to tabs but old code still have spaces, so before to change here I would like to be sure which should be used.
FWIW space with a size of 4 is the most used and recommended.