### PR TITLE
CMake build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.15)
+project(wxFormBuilder
+    VERSION 3.9.1
+    LANGUAGES CXX C
+    DESCRIPTION "An Open Source GUI Builder for wxWidgets"
+    HOMEPAGE_URL "http://wxformbuilder.org"
+)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/scripts/cmake)
+
+option(wxFB_DISABLE_MEDIACTRL "Disable wxMediaCtrl / wxMedia library. [Default: OFF]" OFF)
+
+# TODO: Custom wxWidgets build
+#option(wxFB_DISABLE_SHARED    "Use static wxWidgets build instead of shared libraries. [Default: OFF]" OFF)
+#set(wxFB_WX_ROOT "" CACHE STRING "Install destination for VST bundle [Default: Empty]")
+
+include(wxFBConfig)
+
+if(${wxWidgets_FOUND})
+    include(wxFBLibs)
+    include(wxFormBuilder)
+
+    message(STATUS "
+CMake Generator:             ${CMAKE_GENERATOR}
+
+Project name:                ${PROJECT_NAME}
+Project version:             ${PROJECT_VERSION}
+Build type:                  ${CMAKE_BUILD_TYPE}
+Build processor:             ${wxFB_SYSTEM_PROCESSOR}
+Use clang libc++:            ${wxFB_USE_LIBCPP}
+Install prefix:              ${CMAKE_INSTALL_PREFIX}
+Output directory:            ${CMAKE_BINARY_DIR}
+Disable wxMediaCtrl:         ${wxFB_DISABLE_MEDIACTRL}
+
+wxWidgets version:           ${wxWidgets_VERSION_STRING}
+wxWidgets static:            ${wxWidgets_DEFAULT_STATIC}
+wxWidgets debug:             ${wxWidgets_DEFAULT_DEBUG}
+wxWidgets unicode:           ${wxWidgets_DEFAULT_UNICODE}
+wxWidgets CXX flags:         ${wxWidgets_CXX_FLAGS_LIST}
+
+Compiler CXX debug flags:    ${CMAKE_CXX_FLAGS_DEBUG}
+Compiler CXX release flags:  ${CMAKE_CXX_FLAGS_RELEASE}
+Compiler CXX min size flags: ${CMAKE_CXX_FLAGS_MINSIZEREL}
+")
+endif()
+
+include(Utils)
+#print_all_variables()

--- a/scripts/cmake/Utils.cmake
+++ b/scripts/cmake/Utils.cmake
@@ -1,0 +1,8 @@
+macro (print_all_variables)
+    message(STATUS "===================== VARIABLES BEGIN =====================")
+    get_cmake_property(_variableNames VARIABLES)
+    foreach (_variableName ${_variableNames})
+        message(STATUS "${_variableName}=${${_variableName}}")
+    endforeach()
+    message(STATUS "===================== VARIABLES END =======================")
+endmacro()

--- a/scripts/cmake/wxFBConfig.cmake
+++ b/scripts/cmake/wxFBConfig.cmake
@@ -1,0 +1,57 @@
+# wxFB_DISABLE_MEDIACTRL
+if(UNIX AND NOT wxFB_DISABLE_MEDIACTRL)
+    execute_process(
+        COMMAND wx-config --libs all
+        OUTPUT_VARIABLE _wxLibs
+    )
+    if(_wxLibs MATCHES "media")
+        add_compile_definitions(USE_MEDIACTRL)
+    else()
+        set(wxFB_DISABLE_MEDIACTRL ON)
+    endif()
+endif()
+
+if(WIN32 AND NOT MSYS)
+    list(APPEND wxLibsList gl core base net xml xrc html adv stc richtext propgrid ribbon aui)
+    if(NOT wxFB_DISABLE_MEDIACTRL)
+        list(APPEND wxLibsList media)
+    endif()
+else()
+    list(APPEND wxLibsList all)
+endif()
+
+find_package(wxWidgets 3.0.3 REQUIRED ${wxLibsList})
+if(${wxWidgets_FOUND})
+    include(${wxWidgets_USE_FILE})
+    include(CMakeDependentOption)
+
+    set(CMAKE_CXX_FLAGS_DEBUG "-D__WXFB_DEBUG__ ${CMAKE_CXX_FLAGS_DEBUG}")
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+    if(MSVC)
+        add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+    endif()
+
+    # The variable CMAKE_SYSTEM_PROCESSOR is incorrect on Visual studio, see
+    # https://gitlab.kitware.com/cmake/cmake/issues/15170
+    if(NOT wxFB_SYSTEM_PROCESSOR)
+        if(MSVC)
+            set(wxFB_SYSTEM_PROCESSOR "${MSVC_CXX_ARCHITECTURE_ID}")
+        else()
+            set(wxFB_SYSTEM_PROCESSOR "${CMAKE_SYSTEM_PROCESSOR}")
+        endif()
+    endif()
+
+    # wxFB_USE_LIBCPP: libc++ is enabled by default on macOS.
+    cmake_dependent_option(wxFB_USE_LIBCPP "Use libc++ with clang" "${APPLE}"
+        "CMAKE_CXX_COMPILER_ID MATCHES Clang" OFF)
+    if(wxFB_USE_LIBCPP)
+        add_compile_options(-stdlib=libc++)
+        if(CMAKE_VERSION VERSION_LESS 3.13)
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++ -lc++abi")
+        else()
+            add_link_options(-stdlib=libc++ -lc++abi)
+        endif()
+    endif()
+endif()

--- a/scripts/cmake/wxFBLibs.cmake
+++ b/scripts/cmake/wxFBLibs.cmake
@@ -1,0 +1,55 @@
+# TICPP
+add_subdirectory(subprojects/ticpp)
+add_library(wxfb::ticpp ALIAS ticpp)
+
+# Plugin Interface
+set(wxFB_PLUGIN_INTERFACE_SOURCE_FILES
+    sdk/plugin_interface/component.h
+    sdk/plugin_interface/fontcontainer.h
+    sdk/plugin_interface/plugin.h
+    sdk/plugin_interface/xrcconv.h
+    sdk/plugin_interface/xrcconv.cpp
+    sdk/plugin_interface/forms/wizard.h
+    sdk/plugin_interface/forms/wizard.cpp
+    sdk/plugin_interface/forms/wizard.fbp
+)
+add_library(plugin_interface STATIC ${wxFB_PLUGIN_INTERFACE_SOURCE_FILES})
+add_library(wxfb::plugin_interface ALIAS plugin_interface)
+if(MSVC)
+    # Workaround to unwanted build-type directory added by MSVC
+    set_target_properties(plugin_interface PROPERTIES
+        SUFFIX ".lib"
+        ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<0:>"
+    )
+endif()
+target_link_libraries(plugin_interface wxfb::ticpp ${wxWidgets_LIBRARIES})
+
+# Plugins
+set(wxFBPlugins additional common containers forms layout)
+function(wxfb_add_plugins)
+    foreach(_plugin IN LISTS wxFBPlugins)
+        add_library(${_plugin} MODULE "plugins/${_plugin}/${_plugin}.cpp")
+        add_library(wxfb::${_plugin} ALIAS ${_plugin})
+        if(WIN32)
+            set_target_properties(${_plugin} PROPERTIES
+                PREFIX "lib"
+                SUFFIX ".dll"
+#               LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/plugins/${_plugin}/$<0:>"
+                LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/output/plugins/${_plugin}/$<0:>"
+            )
+        else()
+            set_target_properties(${_plugin} PROPERTIES
+#               LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/wxformbuilder"
+                LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/output/lib/wxformbuilder"
+            )
+        endif()
+        target_compile_definitions(${_plugin} PRIVATE BUILD_DLL)
+        target_include_directories(${_plugin} PRIVATE "sdk/plugin_interface")
+        target_link_libraries(${_plugin}
+            wxfb::ticpp
+            wxfb::plugin_interface
+            ${wxWidgets_LIBRARIES}
+        )
+    endforeach()
+endfunction()
+wxfb_add_plugins()

--- a/scripts/cmake/wxFormBuilder.cmake
+++ b/scripts/cmake/wxFormBuilder.cmake
@@ -1,0 +1,213 @@
+set(wxFB_INCLUDE_FILES
+    src/codegen/codegen.h
+    src/codegen/codeparser.h
+    src/codegen/codewriter.h
+    src/codegen/cppcg.h
+    src/codegen/luacg.h
+    src/codegen/phpcg.h
+    src/codegen/pythoncg.h
+    src/codegen/xrccg.h
+    src/dbg_stack_trace/stack.hpp
+    src/md5/md5.hh
+    src/model/database.h
+    src/model/objectbase.h
+    src/model/types.h
+    src/model/xrcfilter.h
+    src/rad/codeeditor/codeeditor.h
+    src/rad/cpppanel/cpppanel.h
+    src/rad/dataobject/dataobject.h
+    src/rad/designer/innerframe.h
+    src/rad/designer/menubar.h
+    src/rad/designer/visualeditor.h
+    src/rad/designer/visualobj.h
+    src/rad/designer/window_buttons.h
+    src/rad/geninheritclass/geninhertclass.h
+    src/rad/geninheritclass/geninhertclass_gui.h
+    src/rad/inspector/objinspect.h
+    src/rad/inspector/wxfbadvprops.h
+    src/rad/luapanel/luapanel.h
+    src/rad/objecttree/objecttree.h
+    src/rad/phppanel/phppanel.h
+    src/rad/pythonpanel/pythonpanel.h
+    src/rad/xrcpanel/xrcpanel.h
+    src/rad/xrcpreview/xrcpreview.h
+    src/rad/about.h
+    src/rad/appdata.h
+    src/rad/bitmaps.h
+    src/rad/cmdproc.h
+    src/rad/customkeys.h
+    src/rad/genericpanel.h
+    src/rad/mainframe.h
+    src/rad/menueditor.h
+    src/rad/palette.h
+    src/rad/title.h
+    src/rad/wxfbevent.h
+    src/rad/wxfbmanager.h
+    src/utils/annoyingdialog.h
+    src/utils/debug.h
+    src/utils/filetocarray.h
+    src/utils/stringutils.h
+    src/utils/typeconv.h
+    src/utils/wxfbdefs.h
+    src/utils/wxfbexception.h
+    src/utils/wxfbipc.h
+    src/utils/wxlogstring.h
+    src/maingui.h
+    src/pch.h
+    src/rad/geninheritclass/GenInheritedDlg.fbp
+)
+set(wxFB_SOURCE_FILES
+    src/codegen/codegen.cpp
+    src/codegen/codeparser.cpp
+    src/codegen/codewriter.cpp
+    src/codegen/cppcg.cpp
+    src/codegen/luacg.cpp
+    src/codegen/phpcg.cpp
+    src/codegen/pythoncg.cpp
+    src/codegen/xrccg.cpp
+    src/dbg_stack_trace/stack.cpp
+    src/md5/md5.cc
+    src/model/database.cpp
+    src/model/objectbase.cpp
+    src/model/types.cpp
+    src/model/xrcfilter.cpp
+    src/rad/codeeditor/codeeditor.cpp
+    src/rad/cpppanel/cpppanel.cpp
+    src/rad/dataobject/dataobject.cpp
+    src/rad/designer/innerframe.cpp
+    src/rad/designer/menubar.cpp
+#   src/rad/designer/resizablepanel.cpp TODO: ???
+    src/rad/designer/visualeditor.cpp
+    src/rad/designer/visualobj.cpp
+    src/rad/geninheritclass/geninhertclass.cpp
+    src/rad/geninheritclass/geninhertclass_gui.cpp
+    src/rad/inspector/objinspect.cpp
+    src/rad/inspector/wxfbadvprops.cpp
+    src/rad/luapanel/luapanel.cpp
+    src/rad/objecttree/objecttree.cpp
+    src/rad/phppanel/phppanel.cpp
+    src/rad/pythonpanel/pythonpanel.cpp
+    src/rad/xrcpanel/xrcpanel.cpp
+    src/rad/xrcpreview/xrcpreview.cpp
+    src/rad/about.cpp
+    src/rad/appdata.cpp
+    src/rad/bitmaps.cpp
+    src/rad/cmdproc.cpp
+    src/rad/customkeys.cpp
+    src/rad/genericpanel.cpp
+    src/rad/mainframe.cpp
+    src/rad/menueditor.cpp
+    src/rad/palette.cpp
+    src/rad/title.cpp
+    src/rad/wxfbevent.cpp
+    src/rad/wxfbmanager.cpp
+    src/utils/annoyingdialog.cpp
+    src/utils/filetocarray.cpp
+    src/utils/m_wxfb.cpp
+    src/utils/stringutils.cpp
+    src/utils/typeconv.cpp
+    src/utils/wxfbipc.cpp
+    src/maingui.cpp
+)
+if(APPLE)
+    add_executable(${CMAKE_PROJECT_NAME}
+        MACOSX_BUNDLE
+        ${wxFB_INCLUDE_FILES}
+        ${wxFB_SOURCE_FILES}
+        ${wxFB_RESOURCE_FILES}
+    )
+elseif(WIN32)
+    list(APPEND wxFB_SOURCE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/wxFormBuilder.rc")
+
+    add_executable(${CMAKE_PROJECT_NAME}
+        WIN32
+        ${wxFB_INCLUDE_FILES}
+        ${wxFB_SOURCE_FILES}
+        ${wxFB_RESOURCE_FILES}
+    )
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+        SUFFIX ".exe"
+#       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/$<0:>"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/output/$<0:>"
+    )
+    if(MSVC)
+        # wxfbmanager.cpp CHECK_{VISUAL_EDITOR|WX_OBJECT|OBJECT_BASE} macros warnings
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4003")
+        target_link_libraries(${CMAKE_PROJECT_NAME} Dbghelp)
+    else()
+        find_library(BFD_LIB NAMES binutils/libbfd.a libbfd.a)
+        find_library(IBERTY_LIB NAMES binutils/libiberty.a libiberty.a)
+        find_package(ZLIB REQUIRED)
+        find_package(Intl REQUIRED)
+
+        target_link_libraries(${CMAKE_PROJECT_NAME}
+            ${BFD_LIB}
+            ${IBERTY_LIB}
+            ${Intl_LIBRARIES}
+            ${ZLIB_LIBRARIES}
+            psapi
+            imagehlp)
+    endif()
+else()
+    add_executable(${CMAKE_PROJECT_NAME}
+        ${wxFB_INCLUDE_FILES}
+        ${wxFB_SOURCE_FILES}
+        ${wxFB_RESOURCE_FILES}
+    )
+    set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES
+        OUTPUT_NAME "wxformbuilder"
+#       RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/output/bin"
+    )
+endif()
+
+if(MINGW)
+    find_path(BINUTILS_BASE_INCLUDE_DIR binutils/bfd.h)
+    target_include_directories(${CMAKE_PROJECT_NAME}
+        PRIVATE ${BINUTILS_BASE_INCLUDE_DIR}/binutils
+    )
+endif()
+
+target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE
+    "src"
+    "sdk/plugin_interface"
+)
+target_link_libraries(${CMAKE_PROJECT_NAME}
+    ${wxWidgets_LIBRARIES}
+    wxfb::ticpp
+    wxfb::plugin_interface
+)
+if(NOT WIN32)
+    target_link_libraries(${CMAKE_PROJECT_NAME} dl)
+endif()
+
+# Installation
+if (UNIX AND NOT APPLE)
+    include(GNUInstallDirs)
+    install(TARGETS ${PROJECT_NAME}
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    )
+    install(TARGETS ${wxFBPlugins}
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/wxformbuilder"
+    )
+    install(DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}/install/linux/data/gnome/usr/share/appdata"
+        "${CMAKE_CURRENT_SOURCE_DIR}/install/linux/data/gnome/usr/share/applications"
+        "${CMAKE_CURRENT_SOURCE_DIR}/install/linux/data/gnome/usr/share/icons"
+        "${CMAKE_CURRENT_SOURCE_DIR}/install/linux/data/gnome/usr/share/pixmaps"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}"
+    )
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/install/linux/debian/wxformbuilder.sharedmimeinfo"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/mime/packages"
+        RENAME "wxformbuilder.xml"
+    )
+    install(DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}/output/plugins"
+        "${CMAKE_CURRENT_SOURCE_DIR}/output/resources"
+        "${CMAKE_CURRENT_SOURCE_DIR}/output/xml"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/wxformbuilder"
+    )
+    install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/output/license.txt"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/licenses/wxformbuilder"
+    )
+endif()


### PR DESCRIPTION
This (third) alternative CMake build configuration is currently used by myself to code on wxFB, it is tested with Archlinux with wx 3.0.5, MSYS2 and Visual Studio 2019.

I add it as draft PR because I'm still updating it by force pull commits (this is why I marked not editable), it lacks of minor features but it's not yet tested/working on macOS and used in any CI.
The `Utils` module is just for testing, will not part of it and the minimum version required should be less recent, will change it later once all main features will be in.

I took some parts from the `cmake_build` branch (MinGW dependencies).
It uses CMake modules scripts, so it doesn't invasively infest the source code tree, just a single CMakeFiles.txt in the root directory and modules in a `scripts/cmake` folder.

Opened mainly for feedback, requests/suggestions discussion.