### PR TITLE
Use non-macro call for i18n translations

### DIFF
--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -125,7 +125,7 @@ wxString CppTemplateParser::ValueToCode( PropertyType type, wxString value )
 			{
 				if ( m_i18n )
 				{
-					result << wxT( "_(\"" ) << CppCodeGenerator::ConvertCppString( value ) << wxT( "\")" );
+					result << wxT( "wxGetTranslation(\"" ) << CppCodeGenerator::ConvertCppString( value ) << wxT( "\")" );
 				}
 				else
 				{

--- a/src/codegen/phpcg.cpp
+++ b/src/codegen/phpcg.cpp
@@ -128,7 +128,7 @@ wxString PHPTemplateParser::ValueToCode( PropertyType type, wxString value )
 			{
 				if ( m_i18n )
 				{
-					result << wxT("_(\"") << PHPCodeGenerator::ConvertPHPString(value) << wxT("\")");
+					result << wxT("wxGetTranslation(\"") << PHPCodeGenerator::ConvertPHPString(value) << wxT("\")");
 				}
 				else
 				{

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -133,7 +133,7 @@ wxString PythonTemplateParser::ValueToCode( PropertyType type, wxString value )
 			{
 				if ( m_i18n )
 				{
-					result << wxT("_(u\"") << PythonCodeGenerator::ConvertPythonString(value) << wxT("\")");
+					result << wxT("wxGetTranslation(u\"") << PythonCodeGenerator::ConvertPythonString(value) << wxT("\")");
 				}
 				else
 				{


### PR DESCRIPTION
Use wxGetTranslation instead of the optionally-defined macro `_` to get
string translations.

The `_` is defined in `wx/translation.h` but is optionally enabled.  This is needed for codebases that utilize the underscore elsewhere for non-gettext purposes.