### PR TITLE
fix incorrect use of API `wxAuiTabContainer::AddPage`

### DIFF
--- a/src/rad/cpppanel/cpppanel.cpp
+++ b/src/rad/cpppanel/cpppanel.cpp
@@ -69,12 +69,12 @@ wxPanel( parent, id )
 
 	m_cppPanel = new CodeEditor( m_notebook, wxID_ANY);
 	InitStyledTextCtrl( m_cppPanel->GetTextCtrl() );
-	m_notebook->AddPage( m_cppPanel, wxT( "cpp" ), false, 0 );
+	m_notebook->InsertPage( 0, m_cppPanel, wxT( "cpp" ), false );
 	m_notebook->SetPageBitmap( 0, AppBitmaps::GetBitmap( wxT( "cpp" ), 16 ) );
 
 	m_hPanel = new CodeEditor( m_notebook, wxID_ANY);
 	InitStyledTextCtrl( m_hPanel->GetTextCtrl() );
-	m_notebook->AddPage( m_hPanel, wxT( "h" ), false, 1 );
+	m_notebook->InsertPage( 1, m_hPanel, wxT( "h" ), false );
 	m_notebook->SetPageBitmap( 1, AppBitmaps::GetBitmap( wxT( "h" ), 16 ) );
 
 	top_sizer->Add( m_notebook, 1, wxEXPAND, 0 );

--- a/src/rad/inspector/objinspect.cpp
+++ b/src/rad/inspector/objinspect.cpp
@@ -91,8 +91,8 @@ ObjectInspector::ObjectInspector( wxWindow* parent, int id, int style )
 	m_pg = CreatePropertyGridManager(m_nb, WXFB_PROPERTY_GRID);
 	m_eg = CreatePropertyGridManager(m_nb, WXFB_EVENT_GRID);
 
-	m_nb->AddPage( m_pg, _("Properties"), false, 0 );
-	m_nb->AddPage( m_eg, _("Events"),     false, 1 );
+	m_nb->InsertPage( 0, m_pg, _("Properties"), false );
+	m_nb->InsertPage( 1, m_eg, _("Events"),     false );
 
 	m_nb->SetPageBitmap( 0, AppBitmaps::GetBitmap( wxT("properties"), 16 ) );
 	m_nb->SetPageBitmap( 1, AppBitmaps::GetBitmap( wxT("events"), 16 ) );

--- a/src/rad/mainframe.cpp
+++ b/src/rad/mainframe.cpp
@@ -1700,27 +1700,27 @@ wxWindow * MainFrame::CreateDesignerWindow( wxWindow *parent )
 	m_visualEdit = new VisualEditor( m_notebook );
 	AppData()->GetManager()->SetVisualEditor( m_visualEdit );
 
-	m_notebook->AddPage( m_visualEdit, wxT( "Designer" ), false, 0 );
+	m_notebook->InsertPage( 0, m_visualEdit, wxT( "Designer" ), false );
 	m_notebook->SetPageBitmap( 0, AppBitmaps::GetBitmap( wxT( "designer" ), 16 ) );
 
 	m_cpp = new CppPanel( m_notebook, wxID_ANY);
-	m_notebook->AddPage( m_cpp, wxT( "C++" ), false, 1 );
+	m_notebook->InsertPage( 1, m_cpp, wxT( "C++" ), false );
 	m_notebook->SetPageBitmap( 1, AppBitmaps::GetBitmap( wxT( "c++" ), 16 ) );
 
 	m_python = new PythonPanel( m_notebook, wxID_ANY);
-	m_notebook->AddPage( m_python, wxT( "Python" ), false, 2 );
+	m_notebook->InsertPage( 2, m_python, wxT( "Python" ), false );
 	m_notebook->SetPageBitmap( 2, AppBitmaps::GetBitmap( wxT( "python" ), 16 ) );
 
 	m_php = new PHPPanel( m_notebook, wxID_ANY);
-	m_notebook->AddPage( m_php, wxT( "PHP" ), false, 3 );
+	m_notebook->InsertPage( 3, m_php, wxT( "PHP" ), false );
 	m_notebook->SetPageBitmap( 3, AppBitmaps::GetBitmap( wxT( "php" ), 16 ) );
 
 	m_lua = new LuaPanel(m_notebook, wxID_ANY);
-	m_notebook->AddPage(m_lua,wxT( "Lua" ), false, 4 );
+	m_notebook->InsertPage( 4, m_lua,wxT( "Lua" ), false );
 	m_notebook->SetPageBitmap( 4, AppBitmaps::GetBitmap( wxT( "lua" ), 16 ) );
 
 	m_xrc = new XrcPanel( m_notebook, wxID_ANY);
-	m_notebook->AddPage( m_xrc, wxT( "XRC" ), false, 5 );
+	m_notebook->InsertPage( 5, m_xrc, wxT( "XRC" ), false );
 	m_notebook->SetPageBitmap( 5, AppBitmaps::GetBitmap( wxT( "xrc" ), 16 ) );
 
 	return m_notebook;

--- a/src/rad/palette.cpp
+++ b/src/rad/palette.cpp
@@ -185,10 +185,10 @@ void wxFbPalette::Create()
 		if( cursize.x > minsize.x ) minsize.x = cursize.x;
 		if( cursize.y > minsize.y ) minsize.y = cursize.y + 30;
 
-		m_notebook->AddPage(panel, page.first, false, i);
+		m_notebook->InsertPage(i, panel, page.first, false);
 		m_notebook->SetPageBitmap(i, page.second->GetPackageIcon());
-
 	}
+
 	//Title *title = new Title( this, wxT("Component Palette") );
 	//top_sizer->Add(title,0,wxEXPAND,0);
 	top_sizer->Add( m_notebook, 1, wxEXPAND, 0 );


### PR DESCRIPTION
fix incorrect use of API `wxAuiTabContainer::AddPage` where `wxAuiTabContainer::InsertPage` was intended (4th argument used is the page index, not an image ID). This was uncovered by a wxWidget assertion (`wxFAIL_MSG`) firing in `wxWithImages::GetBitmapBundle(int iconIndex)` in an MSVC wxFormBuilder debug build on MSWindows.

(wxWidgets library version used during test: bleeding edge master branch ~ wxWidgets 3.1.6pre, but going through the wxWidgets history, this seems an older mistake as the 3.1.\* API `wxAuiTabContainer::AddPage()` has not been changed/augmented in any way that I could see would make the existing usage of that API correct. In other words: AFAICT this applies for building against **any wxWidgets 3.1.\* version**.)