### PR TITLE
Prevent codegen crash when creating drop-down menus.

### DIFF
--- a/plugins/common/xml/menutoolbar.cppcode
+++ b/plugins/common/xml/menutoolbar.cppcode
@@ -104,7 +104,7 @@ Written by
               #nl wxRect rect = #wxparent $name->GetToolRect( event.GetId() );
               #nl wxPoint pt = #wxparent $name->ClientToScreen( rect.GetBottomLeft() );
               #nl pt = ScreenToClient( pt );
-              #nl #wxparent PopupMenu( $name, pt );
+              #nl #wxparent $name->PopupMenu( $name, pt );
               #nl #wxparent $name->SetToolSticky( event.GetId(), false ); #unindent
             #nl } #unindent
           #nl }

--- a/plugins/common/xml/menutoolbar.phpcode
+++ b/plugins/common/xml/menutoolbar.phpcode
@@ -85,7 +85,7 @@ PHP code generation written by
               #wxparent $name->SetToolSticky( @$event->GetId(), true ); #nl
               @$rect = #wxparent $name->GetToolRect( @$event->GetId() ); #nl
               @$pt = @$this->ScreenToClient( #wxparent $name->ClientToScreen( @$rect->GetBottomLeft() ) ); #nl
-              @$this->PopupMenu( @$this->$name, @$pt ); #nl
+              #wxparent $name->PopupMenu( @$this->$name, @$pt ); #nl
               #wxparent $name->SetToolSticky( @$event->GetId(), false ); #nl #unindent
             } #nl #unindent
           } #nl

--- a/plugins/common/xml/menutoolbar.phpcode
+++ b/plugins/common/xml/menutoolbar.phpcode
@@ -85,7 +85,7 @@ PHP code generation written by
               #wxparent $name->SetToolSticky( @$event->GetId(), true ); #nl
               @$rect = #wxparent $name->GetToolRect( @$event->GetId() ); #nl
               @$pt = @$this->ScreenToClient( #wxparent $name->ClientToScreen( @$rect->GetBottomLeft() ) ); #nl
-              #wxparent @$this->PopupMenu( @$this->$name, @$pt ); #nl
+              @$this->PopupMenu( @$this->$name, @$pt ); #nl
               #wxparent $name->SetToolSticky( @$event->GetId(), false ); #nl #unindent
             } #nl #unindent
           } #nl

--- a/plugins/common/xml/menutoolbar.pythoncode
+++ b/plugins/common/xml/menutoolbar.pythoncode
@@ -82,7 +82,7 @@ Python code generation written by
             #wxparent $name.SetToolSticky( event.GetId(), True ) #nl
             rect = #wxparent $name.GetToolRect( event.GetId() ) #nl
             pt = self.ScreenToClient( #wxparent $name.ClientToScreen( rect.GetBottomLeft() ) ); #nl
-            #wxparent self.PopupMenu( self.$name, pt ) #nl
+            self.PopupMenu( self.$name, pt ) #nl
             #wxparent $name.SetToolSticky( event.GetId(), False ) #nl #unindent #unindent
         @}
       @}@}

--- a/plugins/common/xml/menutoolbar.pythoncode
+++ b/plugins/common/xml/menutoolbar.pythoncode
@@ -82,7 +82,7 @@ Python code generation written by
             #wxparent $name.SetToolSticky( event.GetId(), True ) #nl
             rect = #wxparent $name.GetToolRect( event.GetId() ) #nl
             pt = self.ScreenToClient( #wxparent $name.ClientToScreen( rect.GetBottomLeft() ) ); #nl
-            self.PopupMenu( self.$name, pt ) #nl
+            #wxparent $name.PopupMenu( self.$name, pt ) #nl
             #wxparent $name.SetToolSticky( event.GetId(), False ) #nl #unindent #unindent
         @}
       @}@}


### PR DESCRIPTION
This was caused by what looks like bad cut-and-paste in the templates --- the parameter to a #wxparent was removed without removing the #wxparent too. It'd be good if this was more robust.

I've verified that the C++ generated code works, but the PHP and Python was done blindly. At least the codegen doesn't crash any more.

Fixes: #757