### PR TITLE
Fix build with GCC 13

### DIFF
--- a/third_party/md5/md5/md5.hh
+++ b/third_party/md5/md5/md5.hh
@@ -41,6 +41,7 @@ documentation and/or software.
 #ifndef MD5_MD5_H
 #define MD5_MD5_H
 
+#include <cstdint>
 #include <cstdio>
 #include <istream>
 


### PR DESCRIPTION
Build fails with GCC 13 with an error in `md5.hh`:

```
[   78s] In file included from /home/abuild/rpmbuild/BUILD/wxFormBuilder-3.10.1/src/codegen/codewriter.cpp:29:
[   78s] /home/abuild/rpmbuild/BUILD/wxFormBuilder-3.10.1/src/codegen/../md5/md5.hh:51:49: error: 'uint32_t' has not been declared
[   78s]    51 |   void  update     (const unsigned char* input, uint32_t input_length);
[   78s]       |                                                 ^~~~~~~~
[   78s] /home/abuild/rpmbuild/BUILD/wxFormBuilder-3.10.1/src/codegen/../md5/md5.hh:58:49: error: 'uint32_t' has not been declared
[   78s]    58 |   MD5              (const unsigned char* input, uint32_t input_length); // digest string, finalize
[   78s]       |                                                 ^~~~~~~~
[   78s] /home/abuild/rpmbuild/BUILD/wxFormBuilder-3.10.1/src/codegen/../md5/md5.hh:72:9: error: 'uint32_t' does not name a type
[   78s]    72 |         uint32_t state[4];
[   78s]       |         ^~~~~~~~
[...]
```
(Log is for wxFormBuilder 3.10.1, compiled on openSUSE Tumbleweed (20230417), same issue for wxFormBuilder head.)

This PR just adds an `include <cstdint>` to `md5.hh` so that `uint*_t` can be found.