### PR TITLE
Fix wxRichTextCtrl crash on GNU/Linux

### DIFF
--- a/plugins/additional/additional.cpp
+++ b/plugins/additional/additional.cpp
@@ -353,6 +353,8 @@ public:
         wxFont font(12, wxFONTFAMILY_ROMAN, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
 
         wxRichTextCtrl& r = *richText;
+        r.Freeze();
+        r.SetDefaultStyle(wxRichTextAttr());
         r.SetFont(font);
         r.BeginSuppressUndo();
 
@@ -482,6 +484,7 @@ public:
               "from inline XPMs. Enjoy wxRichTextCtrl!"));
 
         r.EndSuppressUndo();
+        r.Thaw();
 
         return richText;
     }


### PR DESCRIPTION
Hello,

This should solve issue #474, _wxFormBuilder crash on GNU/Linux when inserting a wxRichTextCtrl component_:
- `wxWidgets-3.0.5.1/src/richtext/richtextbuffer.cpp(4729): assert "partialExtents.GetCount() >= (size_t) range.GetLength()" failed in wxRichTextGetRangeWidth()`
- `wxWidgets-3.2.2.1/src/richtext/richtextbuffer.cpp(4961): assert "partialExtents.GetCount() >= (size_t) range.GetLength()" failed in wxRichTextGetRangeWidth()`

This is the [code line crashing wxFormBuilder](https://github.com/wxFormBuilder/wxFormBuilder/blob/19bcc292a2c535e3bca652520bd43fca43f7f9a0/plugins/additional/additional.cpp#L470):
`r.WriteText(wxT("This line contains tabs:\tFirst tab\tSecond tab\tThird tab"));`

Details of the bug/crash, proposed solution, and environment used are below.

Let me know, thanks.

# Proposed solution of the bug/crash
The code snippet causing the problem is pretty much the same as the [wxWidgets v3.0 wxRichTextCtrl online example](https://docs.wxwidgets.org/3.0/overview_richtextctrl.html#overview_richtextctrl_example).

The fix is trivial, a couple of calls are added, [r.Freeze()](https://docs.wxwidgets.org/3.0/classwx_window.html#a15c678314cfc1d807196bc298b713ed3) and `r.Thaw()`, the `r.SetDefaultStyle(wxRichTextAttr())` call in the patch may be superfluous, the solution is suggested by [lines 983-985](https://github.com/wxWidgets/wxWidgets/blob/2740737b40d30817b474e30ff76e43f0903c2e97/samples/richtext/richtext.cpp#L983-L985) and [line 1312](https://github.com/wxWidgets/wxWidgets/blob/2740737b40d30817b474e30ff76e43f0903c2e97/samples/richtext/richtext.cpp#L1312) of the wxWidgets v3.0.5.1 wxRichTextCtrl example.

# Steps to reproduce the bug/crash
1. Start wxFormBuilder;
2. Components -> Forms -> Frame;
3. Components -> Layout -> wxBoxSizer;
4. Components -> Additional -> wxRichTextCtrl.

# Environment used
wxFormBuilder's versions tested (v3.10.1):
- [wxFormBuilder/wxFormBuilder@1fa5400](https://github.com/wxFormBuilder/wxFormBuilder/tree/1fa5400695f68ee22718f4a4a28b2fb63f275145) (ticpp)
- [wxFormBuilder/wxFormBuilder@19bcc29](https://github.com/wxFormBuilder/wxFormBuilder/tree/19bcc292a2c535e3bca652520bd43fca43f7f9a0) (tinyxml2)

wxWidgets's versions used (GTK+ v3.24.38):
- [wxWidgets/wxWidgets@2740737](https://github.com/wxWidgets/wxWidgets/tree/2740737b40d30817b474e30ff76e43f0903c2e97) ([release v3.0.5.1](https://github.com/wxWidgets/wxWidgets/releases/tag/v3.0.5.1))
- [wxWidgets/wxWidgets@a812fff](https://github.com/wxWidgets/wxWidgets/tree/a812fffda3fe686c94e24bff27e8effd96e4de64) ([release v3.2.2.1](https://github.com/wxWidgets/wxWidgets/releases/tag/v3.2.2.1))

System (rolling release):
- Gentoo GNU/Linux amd64