### PR TITLE
Add required Keywords to the desktop file.

### DIFF
--- a/data/platform/linux/share/applications/org.wxformbuilder.wxFormBuilder.desktop
+++ b/data/platform/linux/share/applications/org.wxformbuilder.wxFormBuilder.desktop
@@ -9,3 +9,4 @@ Terminal=false
 Icon=org.wxformbuilder.wxFormBuilder
 MimeType=application/x-wxformbuilder;
 Categories=GTK;GUIDesigner;Development;
+Keywords=wxWidgets;XRC;GUI;builder;designer;


### PR DESCRIPTION
Debian requires that desktop files have a "Keywords" entry as described here: https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords

This patch add some keywords that I thought were appropriate. Please modify them as you see fit. Thanks.