### PR TITLE
fix multiple timers callback bug

### DIFF
--- a/plugins/additional/xml/additional.cppcode
+++ b/plugins/additional/xml/additional.cppcode
@@ -378,7 +378,7 @@ Written by
   <templates class="wxTimer">
     <template name="include">@#include &lt;wx/timer.h&gt;</template>
     <template name="declaration">#class @ $name;</template>
-    <template name="construction">$name.SetOwner( #wxparent $name, $id );</template>
+    <template name="construction">$name.SetOwner( #wxparent $name, $name.GetId() );</template>
     <template name="settings">
       #ifequal $enabled "1"
       @{ $name.Start( $period #ifequal $oneshot "1" @{, true@} ); #nl @}

--- a/plugins/additional/xml/additional.cppcode
+++ b/plugins/additional/xml/additional.cppcode
@@ -384,7 +384,7 @@ Written by
       @{ $name.Start( $period #ifequal $oneshot "1" @{, true@} ); #nl @}
     </template>
     <template name="evt_entry_OnTimer">EVT_TIMER( $id, #handler )</template>
-    <template name="evt_connect_OnTimer">#wxparent $name->Connect( $id, wxEVT_TIMER, #handler );</template>
+    <template name="evt_connect_OnTimer">#wxparent $name->Connect( $name.GetId(), wxEVT_TIMER, #handler );</template>
   </templates>
 
   <templates class="wxStyledTextCtrl">

--- a/plugins/additional/xml/additional.phpcode
+++ b/plugins/additional/xml/additional.phpcode
@@ -262,13 +262,13 @@ PHP code generation written by
   <templates class="wxTimer">
     <template name="construction">
       @$this->$name = new #class(); #nl
-      @$this->$name->SetOwner( #wxparent $name, $id );
+      @$this->$name->SetOwner( #wxparent $name, @$this->$name->GetId() );
     </template>
     <template name="settings">
       #ifequal $enabled "1"
       @{ @$this->$name->Start( $period #ifequal $oneshot "1" @{, true@} ); #nl @}
     </template>
-    <template name="evt_connect_OnTimer">#wxparent $name->Connect( $id, wxEVT_TIMER, #handler );</template>
+    <template name="evt_connect_OnTimer">#wxparent $name->Connect( @$this->$name->GetId(), wxEVT_TIMER, #handler );</template>
   </templates>
 
   <templates class="wxStyledTextCtrl">

--- a/plugins/additional/xml/additional.pythoncode
+++ b/plugins/additional/xml/additional.pythoncode
@@ -272,7 +272,7 @@ Python code generation written by
       #ifequal $enabled "1"
       @{ self.$name.Start( $period #ifequal $oneshot "1" @{, True@} ) #nl @}
     </template>
-    <template name="evt_connect_OnTimer">#wxparent $name.Bind( wx.EVT_TIMER, #handler, id=$id )</template>
+    <template name="evt_connect_OnTimer">#wxparent $name.Bind( wx.EVT_TIMER, #handler, id=self.$name.GetId() )</template>
   </templates>
 
   <templates class="wxStyledTextCtrl">

--- a/plugins/additional/xml/additional.pythoncode
+++ b/plugins/additional/xml/additional.pythoncode
@@ -266,7 +266,7 @@ Python code generation written by
   <templates class="wxTimer">
     <template name="construction">
       self.$name = #class() #nl
-      self.$name.SetOwner( #wxparent $name, $id )
+      self.$name.SetOwner( #wxparent $name, self.$name.GetId() )
     </template>
     <template name="settings">
       #ifequal $enabled "1"


### PR DESCRIPTION
Hello
There is an issue when multiple timers are declared in wxFormBuilder. All the timers launches the same callback when using the connect method.
Here is a fix for python and cpp.

When using an event table, one has to create manually the IDs (like for controls) to avoid such an issue.
Regards
Cedric