### PR TITLE
Fix an issue that generaged XRC has no chance to escape '&' in button label

### DIFF
--- a/sdk/plugin_interface/xrcconv.cpp
+++ b/sdk/plugin_interface/xrcconv.cpp
@@ -56,9 +56,6 @@ static wxString StringToXrcText(const wxString& str)
             case '_':
                 result += "__";
                 break;
-            case '&':
-                result += "_";
-                break;
             default:
                 result += ch;
                 break;


### PR DESCRIPTION
When set 'My && Button' as a button label to expect the button text be "My & Button", '&' will be converted to '_'.
So that the button label in exported XRC will be 'My __ Button'.