### PR TITLE
Add 'Load From SVG Resource' for bitmap property

### DIFF
--- a/src/codegen/cppcg.cpp
+++ b/src/codegen/cppcg.cpp
@@ -256,6 +256,9 @@ wxString CppTemplateParser::ValueToCode(PropertyType type, wxString value)
                     rid = wxT("wxT(\"") + rid + wxT("\")");
 
                 result = wxT("wxArtProvider::GetBitmap( wxASCII_STR(") + rid + wxT("), wxASCII_STR(") + path.AfterFirst(wxT(':')) + wxT(") )");
+            } else if (source == _("Load From SVG Resource")) {
+                result.Printf( wxT("wxBitmapBundle::FromSVGResource( wxT(\"%s\"), {%i, %i} )"),
+                               path, icoSize.GetWidth(), icoSize.GetHeight());
             }
             break;
         }

--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -297,6 +297,9 @@ wxString LuaTemplateParser::ValueToCode(PropertyType type, wxString value)
                 cid.Replace(wxT("wx"), wxT("wx.wx"));
 
                 result = wxT("wx.wxArtProvider.GetBitmap( ") + rid + wxT(", ") + cid + wxT(" )");
+            } else if (source == _("Load From SVG Resource")) {
+                wxLogWarning(wxT("Lua code generation does not support using SVG resources for bitmap properties:\n%s"), path);
+                result = wxT("wx.wxNullBitmap");
             }
             break;
         }

--- a/src/codegen/phpcg.cpp
+++ b/src/codegen/phpcg.cpp
@@ -241,9 +241,10 @@ wxString PHPTemplateParser::ValueToCode(PropertyType type, wxString value)
                     rid = wxT("wxT(\"") + rid + wxT("\")");
 
                 result = wxT("wxArtProvider::GetBitmap( ") + rid + wxT(", ") + path.AfterFirst(wxT(':')) + wxT(" )");
+            } else if (source == _("Load From SVG Resource")) {
+                wxLogWarning(wxT("PHP code generation does not support using SVG resources for bitmap properties:\n%s"), path);
+                result = wxT("wxNullBitmap");
             }
-            break;
-
             break;
         }
         case PT_STRINGLIST: {

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -290,6 +290,10 @@ wxString PythonTemplateParser::ValueToCode(PropertyType type, wxString value)
                 cid.Replace(wxT("wx"), wxT("wx."));
 
                 result = wxT("wx.ArtProvider.GetBitmap( ") + rid + wxT(", ") + cid + wxT(" )");
+            } else if (source == _("Load From SVG Resource")) {
+                wxLogWarning(
+                  wxT("Python code generation does not support using SVG resources for bitmap properties:\n%s"), path);
+                result = wxT("wx.NullBitmap");
             }
             break;
         }

--- a/src/rad/inspector/wxfbadvprops.cpp
+++ b/src/rad/inspector/wxfbadvprops.cpp
@@ -561,7 +561,7 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
                 // 'Load From Icon Resource' and 'Load From SVG Resource'
                 case 3:
                 case 4: {
-                    if (prevSrc != 3 && prevSrc != 4) {
+                    if (prevSrc != childVal) {
                         for (unsigned int i = 1; i < count; ++i) {
                             if (auto* p = Item(i)) {
                                 wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel());

--- a/src/rad/inspector/wxfbadvprops.cpp
+++ b/src/rad/inspector/wxfbadvprops.cpp
@@ -205,11 +205,11 @@ void wxFBBitmapProperty::CreateChildren()
         childIndex = 2;
     } else if (source == wxString(_("Load From Icon Resource"))) {
         childIndex = 3;
-    } else if (source == wxString(_("Load From XRC"))) {
-        childIndex = 4;
-    } else if (source == wxString(_("Load From Art Provider"))) {
-        childIndex = 5;
     } else if (source == wxString(_("Load From SVG Resource"))) {
+        childIndex = 4;
+    } else if (source == wxString(_("Load From XRC"))) {
+        childIndex = 5;
+    } else if (source == wxString(_("Load From Art Provider"))) {
         childIndex = 6;
     }
 
@@ -229,9 +229,9 @@ wxPGProperty* wxFBBitmapProperty::CreatePropertySource(int sourceIndex)
     sourceChoices.Add(_("Load From Embedded File"));
     sourceChoices.Add(_("Load From Resource"));
     sourceChoices.Add(_("Load From Icon Resource"));
+    sourceChoices.Add(_("Load From SVG Resource"));
     sourceChoices.Add(_("Load From XRC"));
     sourceChoices.Add(_("Load From Art Provider"));
-    sourceChoices.Add(_("Load From SVG Resource"));
 
     wxPGProperty* srcProp = new wxEnumProperty(wxT("source"), wxPG_LABEL, sourceChoices, sourceIndex);
     srcProp->SetHelpString(
@@ -243,15 +243,15 @@ wxPGProperty* wxFBBitmapProperty::CreatePropertySource(int sourceIndex)
       wxString(_("Windows Only. Load the image from a BITMAP resource in a .rc file\n\n")) +
       wxString(_("Load From Icon Resource:\n")) +
       wxString(_("Windows Only. Load the image from a ICON resource in a .rc file\n\n")) +
+      wxString(_("Load From SVG Resource:\n")) +
+      wxString(_("On Windows, resource name must be a resource with RT_RCDATA type.\n")) +
+      wxString(_("On MacOS, resource name must be a file with an extension 'svg' placed in the "
+                 "'Resources' subdirectory of the application bundle.\n\n")) +
       wxString(_("Load From XRC:\n")) +
       wxString(
         _("Load the image from XRC resources. The XRC resources must be initialized by the application code.\n\n")) +
       wxString(_("Load From Art Provider:\n")) +
-      wxString(_("Query registered providers for bitmap with given ID.\n\n")) +
-      wxString(_("Load From SVG Resource:\n")) +
-      wxString(_("On Windows, resource name must be a resource with RT_RCDATA type.\n")) +
-      wxString(_("On MacOS, resource name must be a file with an extension 'svg' placed in the "
-                 "'Resources' subdirectory of the application bundle.\n\n")));
+      wxString(_("Query registered providers for bitmap with given ID.\n\n")));
 
     AppendChild(srcProp);
     return srcProp;
@@ -560,8 +560,8 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
                 }
                 // 'Load From Icon Resource' and 'Load From SVG Resource'
                 case 3:
-                case 6: {
-                    if (prevSrc != 3 && prevSrc != 6) {
+                case 4: {
+                    if (prevSrc != 3 && prevSrc != 4) {
                         for (unsigned int i = 1; i < count; ++i) {
                             if (auto* p = Item(i)) {
                                 wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel());
@@ -581,8 +581,8 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
                     break;
                 }
                 // 'Load From XRC'
-                case 4: {
-                    if (prevSrc != 4) {
+                case 5: {
+                    if (prevSrc != 5) {
                         for (unsigned int i = 1; i < count; ++i) {
                             if (auto* p = Item(i)) {
                                 wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel());
@@ -600,8 +600,8 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
                     break;
                 }
                 // 'Load From Art Provider'
-                case 5: {
-                    if (prevSrc != 5) {
+                case 6: {
+                    if (prevSrc != 6) {
                         for (unsigned int i = 1; i < count; ++i) {
                             if (auto* p = Item(i)) {
                                 wxLogDebug(wxT("wxFBBP::ChildChanged: Removing:%s"), p->GetLabel());

--- a/src/rad/inspector/wxfbadvprops.cpp
+++ b/src/rad/inspector/wxfbadvprops.cpp
@@ -289,7 +289,7 @@ wxPGProperty* wxFBBitmapProperty::CreatePropertyIconSize()
     return propIcoSize;
 }
 
-wxPGProperty* wxFBBitmapProperty::CreatePropertyDefSize()
+wxPGProperty* wxFBBitmapProperty::CreatePropertyDefaultSize()
 {
     // Create 'def_size' property ('Load From SVG Resource' only)
     wxPGProperty* propDefSize = new wxFBSizeProperty(wxT("def_size"), wxPG_LABEL, {16, 16});
@@ -518,7 +518,7 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
             const auto count = GetChildCount();
 
             // childValue.GetInteger() returns the chosen item index
-            switch (auto child_val = childValue.GetInteger()) {
+            switch (auto childVal = childValue.GetInteger()) {
                 // 'Load From File' and 'Load From Embedded File'
                 case 0:
                 case 1: {
@@ -569,8 +569,7 @@ wxVariant wxFBBitmapProperty::ChildChanged(wxVariant& thisValue, const int child
                             }
                         }
                         bp->AppendChild(bp->CreatePropertyResourceName());
-                        auto prop = child_val == 3 ? bp->CreatePropertyIconSize() : bp->CreatePropertyDefSize();
-                        bp->AppendChild(prop);
+                        bp->AppendChild(childVal == 3 ? bp->CreatePropertyIconSize() : bp->CreatePropertyDefaultSize());
                     }
 
                     if (childVals.GetCount() == 3) {

--- a/src/rad/inspector/wxfbadvprops.h
+++ b/src/rad/inspector/wxfbadvprops.h
@@ -96,7 +96,7 @@ public:
     wxPGProperty* CreatePropertyFilePath();
     wxPGProperty* CreatePropertyResourceName();
     wxPGProperty* CreatePropertyIconSize();
-    wxPGProperty* CreatePropertyDefSize();
+    wxPGProperty* CreatePropertyDefaultSize();
     wxPGProperty* CreatePropertyXrcName();
     wxPGProperty* CreatePropertyArtId();
     wxPGProperty* CreatePropertyArtClient();

--- a/src/rad/inspector/wxfbadvprops.h
+++ b/src/rad/inspector/wxfbadvprops.h
@@ -96,6 +96,7 @@ public:
     wxPGProperty* CreatePropertyFilePath();
     wxPGProperty* CreatePropertyResourceName();
     wxPGProperty* CreatePropertyIconSize();
+    wxPGProperty* CreatePropertyDefSize();
     wxPGProperty* CreatePropertyXrcName();
     wxPGProperty* CreatePropertyArtId();
     wxPGProperty* CreatePropertyArtClient();


### PR DESCRIPTION
Adds ability to create a bitmap property from SVG resource on Windows or Mac. wxBitmapBundle::FromSVGResource is used for that. The code generation is implemented for C++ only, I am not familiar with wxWidgets library for Python, Lua, etc.
