### PR TITLE
Fix assertion failure on multiline wxTextCtrl

### DIFF
--- a/plugins/common/common.cpp
+++ b/plugins/common/common.cpp
@@ -552,7 +552,11 @@ public:
           obj->GetPropertyAsSize(_("size")),
           obj->GetPropertyAsInteger(_("style")) | obj->GetPropertyAsInteger(_("window_style")));
 
-        if (!obj->IsPropertyNull(_("maxlength"))) {
+        if (!obj->IsPropertyNull(_("maxlength"))
+    #ifdef __WXGTK__
+            && !(obj->GetPropertyAsInteger(_("style")) & wxTE_MULTILINE)
+    #endif
+        ) {
             tc->SetMaxLength(obj->GetPropertyAsInteger(_("maxlength")));
         }
 


### PR DESCRIPTION
When attempting to use a wxTextCtrl with wxTE_MULTILINE, it generates an assertion failure. As wxWidgets documentation says[1], in wxGTK SetMaxLength() may only be used with single line text controls.

[1]: https://docs.wxwidgets.org/3.2/classwx_text_entry.html#a5b9dea0d1adeb9cc14309600de6aff50

Closes: https://github.com/wxFormBuilder/wxFormBuilder/issues/869