### PR TITLE
Add dark appearance support for resources on Windows

### DIFF
--- a/plugins/common/xml/menutoolbar.cppcode
+++ b/plugins/common/xml/menutoolbar.cppcode
@@ -137,8 +137,6 @@ Written by
       $name = new wxMenuItem( #parent $name, $id, wxString( $label ) #ifnotnull $shortcut @{ + wxT('\t') + $shortcut @}, $help, $kind );
     </template>
     <template name="settings">
-      #ifnotequal $kind "wxITEM_RADIO"
-      @{
       #ifnotnull $bitmap
       @{
         @#ifdef __WXMSW__ #nl
@@ -154,7 +152,6 @@ Written by
         @#ifdef __WXMSW__ #nl
         $name->SetBitmaps( wxNullBitmap, $unchecked_bitmap ); #nl
         @#endif #nl
-      @}
       @}
       @}
       #parent $name->Append( $name ); #nl

--- a/src/codegen/cppcg.h
+++ b/src/codegen/cppcg.h
@@ -153,6 +153,11 @@ private:
     void GenAttributeDeclaration(PObjectBase obj, Permission perm, ArrayItems& arrays);
 
     /**
+     * Dark mode helper.
+     */
+    void GenDarkModeHelper();
+
+    /**
      * Recursive function for the validators' variables declaration, used inside GenClassDeclaration.
      */
     void GenValidatorVariables(PObjectBase obj);

--- a/src/codegen/luacg.cpp
+++ b/src/codegen/luacg.cpp
@@ -234,10 +234,11 @@ wxString LuaTemplateParser::ValueToCode(PropertyType type, const wxString& value
             break;
         }
         case PT_BITMAP: {
-            wxString path;
             wxString source;
+            wxString path;
+            wxString path_dark;
             wxSize icoSize;
-            TypeConv::ParseBitmapWithResource(value, &path, &source, &icoSize);
+            TypeConv::ParseBitmapWithResource(value, source, path, path_dark, icoSize);
 
             if (path.empty()) {
                 // Empty path, generate Null Bitmap
@@ -1300,9 +1301,9 @@ void LuaCodeGenerator::GenConstruction(PObjectBase obj, bool is_widget, wxString
             PProperty prop = obj->GetProperty(_("bitmap"));
             if (prop) {
                 wxString oldVal = prop->GetValueAsString();
-                wxString path, source;
+                wxString source, path, path_dark;
                 wxSize toolsize;
-                TypeConv::ParseBitmapWithResource(oldVal, &path, &source, &toolsize);
+                TypeConv::ParseBitmapWithResource(oldVal, source, path, path_dark, toolsize);
                 if (_("Load From Icon Resource") == source && wxDefaultSize == toolsize) {
                     prop->SetValue(wxString::Format(
                       wxT("%s; %s [%i; %i]"), path, source, toolbarsize.GetWidth(), toolbarsize.GetHeight()));

--- a/src/codegen/phpcg.cpp
+++ b/src/codegen/phpcg.cpp
@@ -193,10 +193,11 @@ wxString PHPTemplateParser::ValueToCode(PropertyType type, const wxString& value
             break;
         }
         case PT_BITMAP: {
-            wxString path;
             wxString source;
+            wxString path;
+            wxString path_dark;
             wxSize icoSize;
-            TypeConv::ParseBitmapWithResource(value, &path, &source, &icoSize);
+            TypeConv::ParseBitmapWithResource(value, source, path, path_dark, icoSize);
 
             if (path.empty()) {
                 // Empty path, generate Null Bitmap
@@ -1096,9 +1097,9 @@ void PHPCodeGenerator::GenConstruction(PObjectBase obj, bool is_widget, ArrayIte
             PProperty prop = obj->GetProperty(_("bitmap"));
             if (prop) {
                 wxString oldVal = prop->GetValueAsString();
-                wxString path, source;
+                wxString source, path, path_dark;
                 wxSize toolsize;
-                TypeConv::ParseBitmapWithResource(oldVal, &path, &source, &toolsize);
+                TypeConv::ParseBitmapWithResource(oldVal, source, path, path_dark, toolsize);
                 if (wxT("Load From Icon Resource") == source && wxDefaultSize == toolsize) {
                     prop->SetValue(wxString::Format(
                       wxT("%s; %s [%i; %i]"), path, source, toolbarsize.GetWidth(), toolbarsize.GetHeight()));

--- a/src/codegen/pythoncg.cpp
+++ b/src/codegen/pythoncg.cpp
@@ -229,10 +229,11 @@ wxString PythonTemplateParser::ValueToCode(PropertyType type, const wxString& va
             break;
         }
         case PT_BITMAP: {
-            wxString path;
             wxString source;
+            wxString path;
+            wxString path_dark;
             wxSize icoSize;
-            TypeConv::ParseBitmapWithResource(value, &path, &source, &icoSize);
+            TypeConv::ParseBitmapWithResource(value, source, path, path_dark, icoSize);
 
             if (path.empty()) {
                 // Empty path, generate Null Bitmap
@@ -1189,9 +1190,9 @@ void PythonCodeGenerator::GenConstruction(PObjectBase obj, bool is_widget, Array
             PProperty prop = obj->GetProperty(_("bitmap"));
             if (prop) {
                 wxString oldVal = prop->GetValueAsString();
-                wxString path, source;
+                wxString source, path, path_dark;
                 wxSize toolsize;
-                TypeConv::ParseBitmapWithResource(oldVal, &path, &source, &toolsize);
+                TypeConv::ParseBitmapWithResource(oldVal, source, path, path_dark, toolsize);
                 if (_("Load From Icon Resource") == source && wxDefaultSize == toolsize) {
                     prop->SetValue(wxString::Format(
                       wxT("%s; %s [%i; %i]"), path, source, toolbarsize.GetWidth(), toolbarsize.GetHeight()));

--- a/src/rad/appdata.cpp
+++ b/src/rad/appdata.cpp
@@ -458,7 +458,7 @@ void ApplicationData::Destroy()
 
 
 ApplicationData::ApplicationData(const wxString& rootdir) :
-    m_fbpVersion{1, 19},
+    m_fbpVersion{1, 20},
     m_ipc(std::make_shared<wxFBIPC>()),
     m_rootDir(rootdir),
     m_manager(std::make_shared<wxFBManager>()),
@@ -1232,6 +1232,18 @@ void ApplicationData::ConvertObject(tinyxml2::XMLElement* object, int versionMaj
                 }
 
                 object->DeleteChild(property);
+            }
+        }
+    }
+
+    // Convert to version 1.20
+    if (versionMajor < 1 || (versionMajor == 1 && versionMinor < 20)) {
+        if (auto properties = GetProperties(object, {"bitmap"}); !properties.empty()) {
+            auto* bitmapProperty = *properties.begin();
+            auto bitmapValue = XMLUtils::GetText(bitmapProperty);
+            if (auto pos = bitmapValue.Find(wxT("; [")); pos != wxNOT_FOUND) {
+                bitmapValue.insert(pos, wxT("; ")); // add new attribute 'resource_name_dark'
+                XMLUtils::SetText(bitmapProperty, bitmapValue);
             }
         }
     }

--- a/src/rad/inspector/wxfbadvprops.h
+++ b/src/rad/inspector/wxfbadvprops.h
@@ -68,7 +68,6 @@ class wxFBPointProperty : public wxPGProperty
 public:
     wxFBPointProperty(
       const wxString& label = wxPG_LABEL, const wxString& name = wxPG_LABEL, const wxPoint& value = wxPoint());
-    ~wxFBPointProperty() override;
 
     wxVariant ChildChanged(wxVariant& thisValue, int childIndex, wxVariant& childValue) const override;
 
@@ -89,8 +88,6 @@ class wxFBBitmapProperty : public wxPGProperty
 public:
     wxFBBitmapProperty(
       const wxString& label = wxPG_LABEL, const wxString& name = wxPG_LABEL, const wxString& value = wxString());
-
-    ~wxFBBitmapProperty() override;
 
     wxPGProperty* CreatePropertySource(int sourceIndex = 0);
     wxPGProperty* CreatePropertyFilePath();
@@ -113,9 +110,10 @@ public:
     void UpdateChildValues(const wxString& value);
 
 private:
-    void GetChildValues(const wxString& parentValue, wxArrayString& childValues) const;
+    int m_prevSrc = -1;
 
-    int m_prevSrc;
+    void create_children(int load_from, unsigned int expected_cnt = 0);
+    void GetChildValues(const wxString& parentValue, wxArrayString& childValues) const;
 };
 
 // -----------------------------------------------------------------------
@@ -140,7 +138,6 @@ class wxPGSliderEditor : public wxPGEditor
 public:
     wxPGSliderEditor() : m_max(10000) {}
 
-    ~wxPGSliderEditor() override;
     wxPGWindowList CreateControls(
       wxPropertyGrid* propgrid, wxPGProperty* property, const wxPoint& pos, const wxSize& size) const override;
     void UpdateControl(wxPGProperty* property, wxWindow* wnd) const override;
@@ -164,7 +161,6 @@ public:
     wxFBFontProperty(
       const wxString& label = wxPG_LABEL, const wxString& name = wxPG_LABEL,
       const wxFontContainer& value = *wxNORMAL_FONT);
-    ~wxFBFontProperty() override;
 
     wxVariant ChildChanged(wxVariant& thisValue, int childIndex, wxVariant& childValue) const override;
 

--- a/src/rad/inspector/wxfbadvprops.h
+++ b/src/rad/inspector/wxfbadvprops.h
@@ -95,6 +95,7 @@ public:
     wxPGProperty* CreatePropertySource(int sourceIndex = 0);
     wxPGProperty* CreatePropertyFilePath();
     wxPGProperty* CreatePropertyResourceName();
+    wxPGProperty* CreatePropertyResourceNameDark();
     wxPGProperty* CreatePropertyIconSize();
     wxPGProperty* CreatePropertyDefaultSize();
     wxPGProperty* CreatePropertyXrcName();

--- a/src/utils/typeconv.h
+++ b/src/utils/typeconv.h
@@ -72,7 +72,7 @@ wxString BoolToString(bool val);
 wxArrayString StringToArrayString(const wxString& str);
 wxString ArrayStringToString(const wxArrayString& arrayStr);
 
-void ParseBitmapWithResource(const wxString& value, wxString* image, wxString* source, wxSize* icoSize);
+void ParseBitmapWithResource(const wxString& value, wxString& source, wxString& image, wxString& image_dark, wxSize& icoSize);
 
 /**
 @internal


### PR DESCRIPTION
- wxWidgets 3.3.0 introduced dark appearance support on Windows, see https://wxwidgets.org/blog/2024/10/hello-darkness/
- New bitmap property "resource_name_dark" added to following sources: "Load From Resource", "Load From Icon Resource", "Load From SVG Resource".
- If "resource_name_dark" is not empty and wxSystemSettings::GetAppearance().IsDark() returns true, this resource will be used instead of "resource_name".
- Project file revision bumped to 1.20
- C++: generate SetBitmap(s) for wxMenuItem/wxITEM_RADIO
  - I have no idea why this was turned off for radio items
  - Now you can set bitmaps for them
- Refactoring wxFBBitmapProperty
  - Fix crash in wxFBBitmapProperty::UpdateChildValues during Drag & Drop
    - Sometimes childVals.Count() > GetChildCount(), this causes assertion failure in Item() when the index is invalid.
  - More robust implementation of ChildChanged and UpdateChildValues
  - Remove code duplication
  - Remove empty destructors
  - Improve readability
- All these things are used in my app https://github.com/vadimgrn/usbip-win2/tree/master/userspace/wusbip